### PR TITLE
セット内容編集機能の実装

### DIFF
--- a/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
+++ b/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class WorkoutProcessViewModel: ObservableObject {
+    @Published var exercises: [[String: Any]] = []
+
+    init(exercises: [[String: Any]]) {
+        self.exercises = exercises
+    }
+
+    func getExercise(at index: Int) -> [String: Any]? {
+        guard index >= 0 && index < exercises.count else {
+            return nil
+        }
+        return exercises[index]
+    }
+
+    func updateSetValue(exerciseIndex: Int, setIndex: Int, key: String, newValue: Any) {
+        guard exerciseIndex >= 0, exerciseIndex < exercises.count else { return }
+        guard var exercise = exercises[exerciseIndex] as? [String: Any],
+              var sets = exercise["Sets"] as? [[String: Any]],
+              setIndex >= 0, setIndex < sets.count else { return }
+
+        sets[setIndex][key] = newValue
+        exercise["Sets"] = sets
+        exercises[exerciseIndex] = exercise
+
+        objectWillChange.send()
+    }
+
+    func getTotalExerciseCount() -> Int {
+        return exercises.count
+    }
+}

--- a/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
+++ b/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
@@ -1,7 +1,11 @@
+import Combine
 import Foundation
 
 class WorkoutProcessViewModel: ObservableObject {
     @Published var exercises: [[String: Any]] = []
+    @Published var timerValue: Int = 0
+    private var timer: AnyCancellable?
+    private var isTimerRunning = false
 
     init(exercises: [[String: Any]]) {
         self.exercises = exercises
@@ -60,5 +64,26 @@ class WorkoutProcessViewModel: ObservableObject {
 
     func getTotalExerciseCount() -> Int {
         return exercises.count
+    }
+
+    func startTimer() {
+        guard !isTimerRunning else { return }
+        isTimerRunning = true
+        timer = Timer.publish(every: 1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.timerValue += 1
+            }
+    }
+
+    func stopTimer() {
+        isTimerRunning = false
+        timer?.cancel()
+        timer = nil
+    }
+
+    func resetTimer() {
+        stopTimer()
+        timerValue = 0
     }
 }

--- a/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
+++ b/gymroutine-mobile/ViewModels/WorkoutProcessViewModel.swift
@@ -27,6 +27,37 @@ class WorkoutProcessViewModel: ObservableObject {
         objectWillChange.send()
     }
 
+    func addSet(toExerciseAt exerciseIndex: Int) {
+        guard exerciseIndex >= 0, exerciseIndex < exercises.count else { return }
+        var exercise = exercises[exerciseIndex]
+        var sets = exercise["Sets"] as? [[String: Any]] ?? []
+
+        let newSet: [String: Any] = [
+            "Reps": 0,
+            "Weight": 0,
+            "isDone": false
+        ]
+
+        sets.append(newSet)
+        exercise["Sets"] = sets
+        exercises[exerciseIndex] = exercise
+
+        objectWillChange.send()
+    }
+
+    func removeSet(fromExerciseAt exerciseIndex: Int, setIndex: Int) {
+        guard exerciseIndex >= 0, exerciseIndex < exercises.count else { return }
+        guard var exercise = exercises[exerciseIndex] as? [String: Any],
+              var sets = exercise["Sets"] as? [[String: Any]],
+              setIndex >= 0, setIndex < sets.count else { return }
+
+        sets.remove(at: setIndex)
+        exercise["Sets"] = sets
+        exercises[exerciseIndex] = exercise
+
+        objectWillChange.send()
+    }
+
     func getTotalExerciseCount() -> Int {
         return exercises.count
     }

--- a/gymroutine-mobile/Views/WorkoutProcessView.swift
+++ b/gymroutine-mobile/Views/WorkoutProcessView.swift
@@ -9,6 +9,33 @@ struct WorkoutProcessView: View {
     }
 
     var body: some View {
+
+        VStack {
+            Text("Timer: \(viewModel.timerValue) seconds")
+                .font(.title2)
+                .padding()
+
+            HStack {
+                Button("Start") {
+                    viewModel.startTimer()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Stop") {
+                    viewModel.stopTimer()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Reset") {
+                    viewModel.resetTimer()
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding()
+        }
+
+        Spacer()
+
         VStack {
             if let currentExercise = viewModel.getExercise(at: currentIndex) {
                 Text("Exercise: \(currentExercise["ExerciseName"] as? String ?? "Unknown")")

--- a/gymroutine-mobile/Views/WorkoutProcessView.swift
+++ b/gymroutine-mobile/Views/WorkoutProcessView.swift
@@ -55,6 +55,13 @@ struct WorkoutProcessView: View {
                                 }
                             ))
                             .labelsHidden()
+
+                            Button(action: {
+                                viewModel.removeSet(fromExerciseAt: currentIndex, setIndex: index)
+                            }) {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                            }
                         }
                     }
                 }
@@ -63,6 +70,19 @@ struct WorkoutProcessView: View {
             }
 
             Spacer()
+
+            Button(action: {
+                viewModel.addSet(toExerciseAt: currentIndex)
+            }) {
+                Text("Add Set")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.blue)
+                    .cornerRadius(10)
+            }
+            .padding()
 
             HStack {
                 Button(action: {

--- a/gymroutine-mobile/Views/WorkoutProcessView.swift
+++ b/gymroutine-mobile/Views/WorkoutProcessView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct WorkoutProcessView: View {
+    @StateObject private var viewModel: WorkoutProcessViewModel
+    @State private var currentIndex = 0
+
+    init(exercises: [[String: Any]]) {
+        _viewModel = StateObject(wrappedValue: WorkoutProcessViewModel(exercises: exercises))
+    }
+
+    var body: some View {
+        VStack {
+            if let currentExercise = viewModel.getExercise(at: currentIndex) {
+                Text("Exercise: \(currentExercise["ExerciseName"] as? String ?? "Unknown")")
+                    .font(.headline)
+                Text("Body Part: \(currentExercise["BodyPart"] as? String ?? "Unknown")")
+
+                if let sets = currentExercise["Sets"] as? [[String: Any]] {
+                    List(sets.indices, id: \.self) { index in
+                        let set = sets[index]
+                        HStack {
+                            Text("Set \(index + 1)")
+                                .frame(width: 50, alignment: .leading)
+                            
+                            Text("Reps")
+                            TextField("Reps", text: Binding(
+                                get: { "\(set["Reps"] as? Int ?? 0)" },
+                                set: { newValue in
+                                    if let intValue = Int(newValue) {
+                                        viewModel.updateSetValue(exerciseIndex: currentIndex, setIndex: index, key: "Reps", newValue: intValue)
+                                    }
+                                }
+                            ))
+                            .keyboardType(.numberPad)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .frame(width: 60)
+
+                            Text("Weight")
+                            TextField("Weight", text: Binding(
+                                get: { "\(set["Weight"] as? Int ?? 0)" },
+                                set: { newValue in
+                                    if let intValue = Int(newValue) {
+                                        viewModel.updateSetValue(exerciseIndex: currentIndex, setIndex: index, key: "Weight", newValue: intValue)
+                                    }
+                                }
+                            ))
+                            .keyboardType(.numberPad)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .frame(width: 60)
+
+                            Toggle("Done", isOn: Binding(
+                                get: { set["isDone"] as? Bool ?? false },
+                                set: { newValue in
+                                    viewModel.updateSetValue(exerciseIndex: currentIndex, setIndex: index, key: "isDone", newValue: newValue)
+                                }
+                            ))
+                            .labelsHidden()
+                        }
+                    }
+                }
+            } else {
+                Text("No exercise at index \(currentIndex)")
+            }
+
+            Spacer()
+
+            HStack {
+                Button(action: {
+                    if currentIndex > 0 {
+                        currentIndex -= 1
+                    }
+                }) {
+                    Text("Previous")
+                }
+                Spacer()
+                Button(action: {
+                    if currentIndex < viewModel.getTotalExerciseCount() - 1 {
+                        currentIndex += 1
+                    }
+                }) {
+                    Text("Next")
+                }
+            }
+            .padding()
+        }
+        .padding()
+    }
+}


### PR DESCRIPTION
エクササイズ情報が以下の辞書の配列として渡された際に、set内容を編集する機能を実装した。
時間計測は用途が多岐に渡るので、ひとまずタイマー機能も実装した。
`{ ExerciseName: "hoge", BodyPart: "hoge",Sets: [{ Reps: 12, Weight: 50, isDone: true}] } `
<img width="333" alt="スクリーンショット 2025-01-13 14 05 58" src="https://github.com/user-attachments/assets/649747c1-8e25-4abd-946c-7eb00141ddc3" />

