### PR TITLE
[SP9-9,10,11] ホーム画面の仮構成

### DIFF
--- a/gymroutine-mobile/ViewParts/Cells/WorkoutCell.swift
+++ b/gymroutine-mobile/ViewParts/Cells/WorkoutCell.swift
@@ -1,0 +1,60 @@
+//
+//  WorkoutCell.swift
+//  gymroutine-mobile
+//
+//  Created by SATTSAT on 2025/01/09
+//
+//
+
+import SwiftUI
+
+struct WorkoutCell: View {
+    
+    //workoutモデルがないため仮の変数を宣言
+    let workoutName: String = "一軍ワークアウト"
+    let count: Int = 6
+    let profileImageUrl: String? = nil
+    var body: some View {
+        HStack {
+            Group {
+                if let profileImageUrl {
+                    //URLが存在したら、URLから画像を取得するKingFisherパッケージなどを導入してここに追加
+                    Text("URLから画像処理")
+                } else {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.main)
+                        .frame(width: 48, height: 48)
+                }
+            }
+            
+            VStack(alignment: .leading) {
+                Text("\(count)種目")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                
+                Text(workoutName)
+                    .font(.headline)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            Text("〉")
+                .foregroundStyle(.secondary)
+                .bold()
+        }
+        .padding(8)
+        .background(.background)
+        .clipShape(.rect(cornerRadius: 8))
+    }
+}
+
+#Preview {
+    ScrollView {
+        WorkoutCell()
+        WorkoutCell()
+        WorkoutCell()
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(.secondary)
+}

--- a/gymroutine-mobile/Views/HomeView.swift
+++ b/gymroutine-mobile/Views/HomeView.swift
@@ -84,8 +84,9 @@ struct HomeView: View {
                     Text("今日のワークアウト")
                         .font(.title2.bold())
                     
-                    Image(systemName: isShowTodayworkouts ? "chevron.up" : "chevron.down")
+                    Image(systemName: "chevron.right")
                         .fontWeight(.semibold)
+                        .rotationEffect(.degrees(isShowTodayworkouts ? 90 : 0))
                 }
                 .hAlign(.leading)
             }

--- a/gymroutine-mobile/Views/HomeView.swift
+++ b/gymroutine-mobile/Views/HomeView.swift
@@ -2,33 +2,179 @@
 //  HomeView.swift
 //  gymroutine-mobile
 //
-//  Created by 조성화 on 2024/12/27.
+//  Created by SATTSAT on 2024/12/26
+//
 //
 
-import Foundation
 import SwiftUI
 
 struct HomeView: View {
-    @EnvironmentObject var userManager: UserManager
     @ObservedObject var viewModel: MainViewModel
+    @EnvironmentObject var userManager: UserManager
+    
+    @State private var isShowTodayworkouts = true
     
     var body: some View {
-        VStack {
-            if let email = userManager.currentUser?.email {
-                Text("\(email)でログインしました！")
-                    .font(.headline)
-            } else {
-                Text("ユーザー情報がありません")
-                    .font(.headline)
-            }
+        ScrollView(showsIndicators: false) {
             
+            header
+            
+            VStack(spacing: 24) {
+                
+                calendarBox
+                
+                todaysWorkoutsBox
+                
+                userInfoBox
+            }
+            .padding()
+        }
+        .background(Color.gray.opacity(0.1))
+        .contentMargins(.top, 16)
+        .contentMargins(.bottom, 80)
+        .overlay(alignment: .bottom) {
+            buttonBox
+                .clipped()
+                .shadow(radius: 4)
+                .padding()
+        }
+    }
+    
+    private var header: some View {
+        VStack(spacing: 16) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 16) {
+                    //仮表示
+                    ForEach(0..<20) {_ in
+                        Circle()
+                            .fill(.main)
+                            .frame(width: 80, height: 80)
+                    }
+                }
+            }
+            .contentMargins(.horizontal, 16)
+            
+            Label("現在2人が筋トレしています！", systemImage: "flame")
+                .fontWeight(.semibold)
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+                .hAlign(.leading)
+                .background(.red.opacity(0.3))
+        }
+    }
+    
+    private var calendarBox: some View {
+        VStack {
+            Text("簡易カレンダーView")
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 200)
+        .background()
+        .clipShape(.rect(cornerRadius: 8))
+    }
+    
+    private var todaysWorkoutsBox: some View {
+        VStack {
             Button {
-                viewModel.logout()
+                withAnimation() {
+                    isShowTodayworkouts.toggle()
+                }
             } label: {
-                Text("ログアウトするよ")
+                HStack {
+                    Text("今日のワークアウト")
+                        .font(.title2.bold())
+                    
+                    Image(systemName: isShowTodayworkouts ? "chevron.up" : "chevron.down")
+                        .fontWeight(.semibold)
+                }
+                .hAlign(.leading)
+            }
+            .foregroundStyle(.primary)
+            
+            if isShowTodayworkouts {
+                //仮表示
+                ForEach(0..<2) {_ in
+                    WorkoutCell()
+                }
             }
         }
-        .padding()
-        .navigationTitle("Home")
     }
+    
+    private var userInfoBox: some View {
+        VStack {
+            if let user = userManager.currentUser {
+                Text("\(user.name)の情報")
+                    .font(.title2.bold())
+                    .hAlign(.leading)
+                
+                //仮情報
+                HStack {
+                    VStack(spacing: 16) {
+                        Text("累計トレーニング日数")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                            .hAlign(.leading)
+                        
+                        HStack(alignment: .bottom) {
+                            Text("128")
+                                .font(.largeTitle.bold())
+                            
+                            Text("日")
+                        }
+                        .hAlign(.trailing)
+                    }
+                    .padding()
+                    .hAlign(.center)
+                    .frame(height: 108)
+                    .background()
+                    .clipShape(.rect(cornerRadius: 8))
+                    
+                    VStack {
+                        Text("現在の体重")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                            .hAlign(.leading)
+                        
+                        HStack(alignment: .bottom) {
+                            Text("64")
+                                .font(.largeTitle.bold())
+                            
+                            Text("kg")
+                        }
+                        .hAlign(.trailing)
+                    }
+                    .padding()
+                    .hAlign(.center)
+                    .frame(height: 108)
+                    .background()
+                    .clipShape(.rect(cornerRadius: 8))
+                }
+            } else {
+                Text("ユーザー情報が読み込めません")
+            }
+        }
+    }
+    
+    private var buttonBox: some View {
+        HStack {
+            Button {
+                
+            } label: {
+                Label("ルーティーン追加", systemImage: "plus")
+            }
+            .buttonStyle(SecondaryButtonStyle())
+            
+            Button {
+                
+            } label: {
+                Label("今すぐ始める", systemImage: "play")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+    }
+}
+
+#Preview {
+    HomeView(viewModel: MainViewModel(router: Router()))
+        .environmentObject(UserManager.shared)
 }


### PR DESCRIPTION
## ホーム画面を構成しました
### 実装したこと
- カスタムセル一覧を入れる、CellsフォルダをViewPartsフォルダの中に追加
- ワークアウトを一覧表示する際に使用するカスタムセルを作成
- HomeViewを構成
- HomeViewにおける「今日のワークアウト」は、開閉可能な仕様にしました

### 改善事項
- Workoutモデルを実装時に仮引数をモデルに差し替え
- バックエンド側で画像アップロード処理を実装後、高速でURLから画像を取得する「Swift Package Manager（KingFisherやNuke）」を導入
- ホーム画面（HomeView）は、ViewModelが確立後、全体的に差し替え

### スクリーンショット
| WorkoutCell   |
|------------|
| <img src="https://github.com/user-attachments/assets/dae44ceb-d76b-4a57-9cde-60a8a114a0e0" alt="IMG_3472" width="300px" />  |  |

| MainView(今日のワークアウト表示時)   | MainView(今日のワークアウト非表示時) |
|------------| ------------| 
| <img src="https://github.com/user-attachments/assets/133fc70c-2f7e-4582-9c9c-b8a50c397953" alt="IMG_3472" width="300px" />  | <img src="https://github.com/user-attachments/assets/4402aaa6-c3aa-49d4-a927-8179f1ab39d5" alt="IMG_3472" width="300px" />  |






