### PR TITLE
プロフィール初期設定画面・パスワードを探す画面UI実装

### DIFF
--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -22,11 +22,13 @@ final class InitProfileSetupViewModel: ObservableObject {
     @Published var birthday: Date = Date()
     @Published var errorMessage: String? = nil
     @Published var isSignedUp: Bool = false
-    
+    @Published var currentStep: SetupStep = .nickname
+
     private let router: Router
     private var cancellables = Set<AnyCancellable>()
     private let authService = AuthService()
-    
+    let setupSteps: [SetupStep] = SetupStep.allCases
+
     init(router: Router) {
         self.router = router
     }
@@ -75,10 +77,31 @@ final class InitProfileSetupViewModel: ObservableObject {
     func isSelectedGender(_ gender: Gender) -> Bool {
         return self.gender == gender
     }
+
+    func toNextStep(_ nextStep: SetupStep) {
+        self.currentStep = nextStep
+    }
 }
 
-// MARK: - Gender
+// MARK: - Enums
 extension InitProfileSetupViewModel {
+    enum SetupStep: CaseIterable {
+        case nickname
+        case gender
+        case birthday
+
+        var nextStep: SetupStep? {
+            switch self {
+            case .nickname:
+                return    .gender
+            case .gender:
+                return   .birthday
+            case .birthday:
+                return nil
+            }
+        }
+    }
+
     enum Gender: String, CaseIterable {
         case man = "男性"
         case woman = "女性"

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -119,17 +119,6 @@ extension InitProfileSetupViewModel {
     enum Gender: String, CaseIterable {
         case man = "男性"
         case woman = "女性"
-        case noSelection = "未選択"
-
-        var displeyText: String {
-            switch self {
-            case .man:
-                "男性"
-            case .woman:
-                "女性"
-            case .noSelection:
-                "選択しない"
-            }
-        }
+        case other = "その他"
     }
 }

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -54,7 +54,7 @@ final class InitProfileSetupViewModel: ObservableObject {
             visibility: 2,
             isActive: false,
             birthday: self.birthday,
-            gender: self.gender?.rawValue ?? "未選択",
+            gender: self.gender?.rawValue ?? Gender.noAnswer.rawValue,
             createdAt: Date()
         )
         

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -18,7 +18,7 @@ final class InitProfileSetupViewModel: ObservableObject {
     @Published var confirmPassword: String = ""
     @Published var name: String = ""
     @Published var age: Int = 0
-    @Published var gender: String = ""
+    @Published var gender: Gender? = nil
     @Published var birthday: Date = Date()
     @Published var errorMessage: String? = nil
     @Published var isSignedUp: Bool = false
@@ -49,7 +49,7 @@ final class InitProfileSetupViewModel: ObservableObject {
             visibility: 2,
             isActive: false,
             birthday: self.birthday,
-            gender: self.gender,
+            gender: self.gender?.rawValue ?? "未選択",
             createdAt: Date()
         )
         
@@ -63,6 +63,36 @@ final class InitProfileSetupViewModel: ObservableObject {
                 self.errorMessage = error.localizedDescription
             }
             //ローディング画面非表示
+        }
+    }
+
+    /// on tap gender button
+    func selectGender(_ gender: Gender) {
+        self.gender = gender
+    }
+
+    /// for gender button UI
+    func isSelectedGender(_ gender: Gender) -> Bool {
+        return self.gender == gender
+    }
+}
+
+// MARK: - Gender
+extension InitProfileSetupViewModel {
+    enum Gender: String, CaseIterable {
+        case man = "男性"
+        case woman = "女性"
+        case noSelection = "未選択"
+
+        var displeyText: String {
+            switch self {
+            case .man:
+                "男性"
+            case .woman:
+                "女性"
+            case .noSelection:
+                "選択しない"
+            }
         }
     }
 }

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -92,8 +92,8 @@ final class InitProfileSetupViewModel: ObservableObject {
         }
     }
 
-    func toNextStep(_ nextStep: SetupStep) {
-        self.currentStep = nextStep
+    func moveToStep(_ step: SetupStep) {
+        self.currentStep = step
     }
 }
 
@@ -105,14 +105,19 @@ extension InitProfileSetupViewModel {
         case birthday
 
         var nextStep: SetupStep? {
-            switch self {
-            case .nickname:
-                return    .gender
-            case .gender:
-                return   .birthday
-            case .birthday:
+            guard let currentIndex = Self.allCases.firstIndex(of: self),
+                  currentIndex < Self.allCases.count - 1 else {
                 return nil
             }
+            return Self.allCases[currentIndex + 1]
+        }
+
+        var previousStep: SetupStep? {
+            guard let currentIndex = Self.allCases.firstIndex(of: self),
+                  currentIndex > 0 else {
+                return nil
+            }
+            return Self.allCases[currentIndex - 1]
         }
     }
 

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -31,6 +31,9 @@ final class InitProfileSetupViewModel: ObservableObject {
 
     init(router: Router) {
         self.router = router
+
+        // 初期値 2000年1月1日
+        birthday = Calendar.current.date(from: DateComponents(year: 2000, month: 1, day: 1)) ?? Date()
     }
 
     /// Firestore - save user info

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -124,6 +124,6 @@ extension InitProfileSetupViewModel {
     enum Gender: String, CaseIterable {
         case man = "男性"
         case woman = "女性"
-        case other = "その他"
+        case noAnswer = "無回答"
     }
 }

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -78,6 +78,17 @@ final class InitProfileSetupViewModel: ObservableObject {
         return self.gender == gender
     }
 
+    func isDisabledActionButton() -> Bool {
+        switch currentStep {
+        case .nickname:
+            return name.isEmpty
+        case .gender:
+            return gender == nil
+        case .birthday:
+            return false
+        }
+    }
+
     func toNextStep(_ nextStep: SetupStep) {
         self.currentStep = nextStep
     }

--- a/gymroutine-mobile/ViewModels/PasswordResetViewModel.swift
+++ b/gymroutine-mobile/ViewModels/PasswordResetViewModel.swift
@@ -13,6 +13,9 @@ class PasswordResetViewModel: ObservableObject {
 
     init(authService: AuthService) {
         self.authService = authService
+
+        // 初期値 2000年1月1日
+        birthday = Calendar.current.date(from: DateComponents(year: 2000, month: 1, day: 1)) ?? Date()
     }
 
     func sendPasswordReset() {

--- a/gymroutine-mobile/ViewParts/Buttons/CircleButtonStyle.swift
+++ b/gymroutine-mobile/ViewParts/Buttons/CircleButtonStyle.swift
@@ -13,7 +13,7 @@ import SwiftUI
  ### 形
  - 円形
  ### 用途
- - ログイン・新規登録の実行ボタン
+ - 新規登録後のプロフィール登録のネクストボタン
  */
 struct CircleButtonStyle: ButtonStyle {
 

--- a/gymroutine-mobile/ViewParts/Buttons/CircleButtonStyle.swift
+++ b/gymroutine-mobile/ViewParts/Buttons/CircleButtonStyle.swift
@@ -17,12 +17,14 @@ import SwiftUI
  */
 struct CircleButtonStyle: ButtonStyle {
 
+    @Environment(\.isEnabled) var isEnabled: Bool
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.title)
             .foregroundStyle(.white)
             .padding(20)
             .background(.main, in: Circle())
-            .opacity(configuration.isPressed ? 0.5 : 1.0)
+            .opacity(configuration.isPressed || !self.isEnabled ? 0.5 : 1.0)
     }
 }

--- a/gymroutine-mobile/ViewParts/Buttons/PrimaryButtonStyle.swift
+++ b/gymroutine-mobile/ViewParts/Buttons/PrimaryButtonStyle.swift
@@ -17,12 +17,14 @@ import SwiftUI
  */
 struct PrimaryButtonStyle: ButtonStyle {
 
+    @Environment(\.isEnabled) var isEnabled: Bool
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.headline)
             .foregroundStyle(.white)
             .frame(maxWidth: 315, maxHeight: 48)
             .background(Color.main.cornerRadius(10))
-            .opacity(configuration.isPressed ? 0.5 : 1.0)
+            .opacity(configuration.isPressed || !self.isEnabled ? 0.5 : 1.0)
     }
 }

--- a/gymroutine-mobile/ViewParts/Buttons/SecondaryCircleButtonStyle.swift
+++ b/gymroutine-mobile/ViewParts/Buttons/SecondaryCircleButtonStyle.swift
@@ -1,0 +1,30 @@
+//
+//  SecondaryCircleButtonStyle.swift
+//  gymroutine-mobile
+//
+//  Created by 森祐樹 on 2025/01/13.
+//
+
+import SwiftUI
+
+/**
+ ### 背景色
+ -`systemGray5`
+ ### 形
+ - 円形
+ ### 用途
+ - 新規登録後のプロフィール登録のバックボタン
+ */
+struct SecondaryCircleButtonStyle: ButtonStyle {
+
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.title)
+            .foregroundStyle(.main)
+            .padding(20)
+            .background(Color(UIColor.systemGray5), in: Circle())
+            .opacity(configuration.isPressed || !self.isEnabled ? 0.5 : 1.0)
+    }
+}

--- a/gymroutine-mobile/ViewParts/Buttons/SelectableButtonStyle.swift
+++ b/gymroutine-mobile/ViewParts/Buttons/SelectableButtonStyle.swift
@@ -1,0 +1,34 @@
+//
+//  SelectableButtonStyle.swift
+//  gymroutine-mobile
+//
+//  Created by 森祐樹 on 2024/12/30.
+//
+
+import SwiftUI
+
+/**
+ ### 背景色
+ - 選択時：`main` / 未選択時：`secondary`
+ ### 形
+ - 横長長方形・角丸
+ ### 用途
+ - 性別選択
+ */
+struct SelectableButtonStyle: ButtonStyle {
+    let isSelected: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .bold()
+            .foregroundStyle(isSelected ? .main : .secondary)
+            .hAlign(.center)
+            .padding(.vertical, 20)
+            .background {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.main.opacity(0.1) : .clear)
+                    .strokeBorder(isSelected ? .main : .secondary, lineWidth: 1)
+            }
+            .contentShape(Rectangle())
+    }
+}

--- a/gymroutine-mobile/ViewParts/CustomTabBar.swift
+++ b/gymroutine-mobile/ViewParts/CustomTabBar.swift
@@ -1,0 +1,51 @@
+//
+//  TabBarView.swift
+//  gymroutine-mobile
+//
+//  Created by 森祐樹 on 2024/12/31.
+//
+
+import SwiftUI
+
+struct CustomTabBar<T: Hashable & Equatable>: View {
+
+    let items: [T]
+    let currentItem: T
+    @Namespace var namespace
+
+    var body: some View {
+        HStack(alignment: .bottom) {
+            ForEach(items, id: \.self) { item in
+                CustomTabBarItem(item: item,
+                                 currentItem: currentItem,
+                                 namespace: namespace)
+            }
+        }
+    }
+
+    struct CustomTabBarItem: View {
+
+        let item: T
+        let currentItem: T
+        let namespace: Namespace.ID
+
+        var body: some View {
+            Group {
+                if currentItem == item {
+                    ZStack {
+                        Color(.systemGray4)
+
+                        Color.main
+                            .matchedGeometryEffect(id: "line",
+                                                   in: namespace,
+                                                   properties: .frame)
+                    }
+                } else {
+                    Color(.systemGray4)
+                }
+            }
+            .frame(height: 2)
+            .animation(.spring(), value: currentItem)
+        }
+    }
+}

--- a/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
+++ b/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
@@ -34,12 +34,14 @@ struct DateInputField: View {
             }
             .focused($isActive)
             .toolbar {
-                ToolbarItem(placement: .keyboard) {
-                    Button("完了") {
-                        isActive = false
+                if isActive {
+                    ToolbarItem(placement: .keyboard) {
+                        Button("完了") {
+                            isActive = false
+                        }
+                        .tint(.primary)
+                        .hAlign(.trailing)
                     }
-                    .tint(.primary)
-                    .hAlign(.trailing)
                 }
             }
     }

--- a/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
+++ b/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
@@ -70,7 +70,19 @@ fileprivate struct AddInputViewToTextField<Content: View>: UIViewRepresentable {
         return view
     }
 
-    func updateUIView(_ uiView: UIViewType, context: Context) { }
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        DispatchQueue.main.async {
+            if let window = uiView.window, let textField = window.allSubViews(type: UITextField.self).first(where: {$0.placeholder == id}) {
+                textField.tintColor = .clear
+                let hostView = UIHostingController(rootView: content).view!
+                hostView.backgroundColor = .clear
+                hostView.frame.size = hostView.intrinsicContentSize
+
+                textField.inputView = hostView
+                textField.reloadInputViews()
+            }
+        }
+    }
 }
 
 fileprivate extension UIView {

--- a/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
+++ b/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
@@ -1,0 +1,93 @@
+//
+//  DateTF.swift
+//  gymroutine-mobile
+//
+//  Created by 森祐樹 on 2025/01/01.
+//
+
+import SwiftUI
+
+/// キーボードの代わりにDatePickerを表示させ、日付を入力するカスタムビュー
+/// 参考: https://www.youtube.com/watch?v=wnrtI4qXghc
+struct DateInputField: View {
+
+    var components: DatePickerComponents = .date
+    @Binding var date: Date
+    var formattedString: (Date) -> String
+
+    @State private var viewId: String = UUID().uuidString
+    @FocusState private var isActive
+
+    var body: some View {
+        TextField(viewId, text: .constant(formattedString(date)))
+            .overlay {
+                AddInputViewToTextField(id: viewId) {
+                    DatePicker("", selection: $date, in: ...Date(), displayedComponents: components)
+                        .labelsHidden()
+                        .datePickerStyle(.wheel)
+                        .environment(\.locale, Locale(identifier: "ja_JP"))
+                        .padding(.vertical, 32)
+                }
+                .onTapGesture {
+                    isActive = true
+                }
+            }
+            .bold()
+            .fieldBackground()
+            .focused($isActive)
+            .toolbar {
+                ToolbarItem(placement: .keyboard) {
+                    Button("完了") {
+                        isActive = false
+                    }
+                    .tint(.primary)
+                    .hAlign(.trailing)
+                }
+            }
+    }
+}
+
+fileprivate struct AddInputViewToTextField<Content: View>: UIViewRepresentable {
+    var id: String
+    @ViewBuilder var content: Content
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+
+        DispatchQueue.main.async {
+            if let window = view.window, let textField = window.allSubViews(type: UITextField.self).first(where: {$0.placeholder == id}) {
+                textField.tintColor = .clear
+                let hostView = UIHostingController(rootView: content).view!
+                hostView.backgroundColor = .clear
+                hostView.frame.size = hostView.intrinsicContentSize
+
+                textField.inputView = hostView
+                textField.reloadInputViews()
+            }
+        }
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIViewType, context: Context) { }
+}
+
+fileprivate extension UIView {
+    func allSubViews<T: UIView>(type: T.Type) -> [T] {
+        var resultViews = subviews.compactMap({ $0 as? T })
+
+        for view in subviews {
+            resultViews.append(contentsOf: view.allSubViews(type: type))
+        }
+
+        return resultViews
+    }
+}
+
+#Preview {
+    @Previewable @State var date = Date()
+    DateInputField(date: $date) { date in
+        return date.formatted()
+    }
+}

--- a/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
+++ b/gymroutine-mobile/ViewParts/InputText/DateInputField.swift
@@ -32,8 +32,6 @@ struct DateInputField: View {
                     isActive = true
                 }
             }
-            .bold()
-            .fieldBackground()
             .focused($isActive)
             .toolbar {
                 ToolbarItem(placement: .keyboard) {

--- a/gymroutine-mobile/ViewParts/InputText/EmailAddressField.swift
+++ b/gymroutine-mobile/ViewParts/InputText/EmailAddressField.swift
@@ -14,6 +14,7 @@ struct EmailAddressField: View {
     var body: some View {
         TextField("", text: $text)
             .keyboardType(.emailAddress)
+            .submitLabel(.done)
             .disableAutocorrection(true)    // typo警告を非表示
             .textInputAutocapitalization(.never)
             .fieldBackground()

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -78,14 +78,18 @@ extension InitProfileSetupView {
         .sensoryFeedback(.selection, trigger: viewModel.gender)
     }
 
-    // TODO: OTP風の入力にする
     private var birthdayView: some View {
         VStack(alignment: .leading, spacing: 32) {
             Text("生年月日を教えてください")
                 .font(.title)
                 .bold()
 
-            DatePicker("", selection: $viewModel.birthday, displayedComponents: .date)
+            DateInputField(date: $viewModel.birthday) { date in
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "ja_JP") // 日本語ロケール
+                formatter.dateStyle = .long
+                return formatter.string(from: date)
+            }
         }
     }
 

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -70,7 +70,7 @@ extension InitProfileSetupView {
                     Button {
                         viewModel.selectGender(gender)
                     } label: {
-                        Text(gender.displeyText)
+                        Text(gender.rawValue)
                     }
                     .buttonStyle(SelectableButtonStyle(isSelected: viewModel.isSelectedGender(gender)))
                 }

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -106,25 +106,36 @@ extension InitProfileSetupView {
     }
 
     private var actionButton: some View {
-        Group {
-            if let nextStep = viewModel.currentStep.nextStep {
+        HStack(spacing: 0) {
+            if let previousStep = viewModel.currentStep.previousStep {
                 Button {
-                    viewModel.toNextStep(nextStep)
+                    viewModel.moveToStep(previousStep)
                 } label: {
-                    Image(systemName: "chevron.forward")
+                    Image(systemName: "chevron.backward")
                 }
-                .buttonStyle(CircleButtonStyle())
-                .hAlign(.trailing)
-            } else {
-                Button {
-                    viewModel.saveAdditionalInfo()
-                } label: {
-                    Text("登録する")
-                }
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(SecondaryCircleButtonStyle())
             }
+
+            Spacer()
+
+            Group {
+                if let nextStep = viewModel.currentStep.nextStep {
+                    Button {
+                        viewModel.moveToStep(nextStep)
+                    } label: {
+                        Image(systemName: "chevron.forward")
+                    }
+                } else {
+                    Button {
+                        viewModel.saveAdditionalInfo()
+                    } label: {
+                        Image(systemName: "chevron.forward")
+                    }
+                }
+            }
+            .buttonStyle(CircleButtonStyle())
+            .disabled(viewModel.isDisabledActionButton())
         }
-        .disabled(viewModel.isDisabledActionButton())
     }
 }
 

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -32,6 +32,7 @@ struct InitProfileSetupView: View {
             Spacer()
 
             actionButton
+                .padding(.horizontal, 24)
         }
         .padding(.vertical, 24)
     }
@@ -110,17 +111,19 @@ extension InitProfileSetupView {
                 Button {
                     viewModel.toNextStep(nextStep)
                 } label: {
-                    Text("次へ")
+                    Image(systemName: "chevron.forward")
                 }
+                .buttonStyle(CircleButtonStyle())
+                .hAlign(.trailing)
             } else {
                 Button {
                     viewModel.saveAdditionalInfo()
                 } label: {
                     Text("登録する")
                 }
+                .buttonStyle(PrimaryButtonStyle())
             }
         }
-        .buttonStyle(PrimaryButtonStyle())
         .disabled(viewModel.isDisabledActionButton())
     }
 }

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -89,7 +89,6 @@ extension InitProfileSetupView {
         }
     }
 
-    // TODO: disable対応
     private var actionButton: some View {
         Group {
             if let nextStep = viewModel.currentStep.nextStep {
@@ -107,6 +106,7 @@ extension InitProfileSetupView {
             }
         }
         .buttonStyle(PrimaryButtonStyle())
+        .disabled(viewModel.isDisabledActionButton())
     }
 }
 

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -18,14 +18,19 @@ struct InitProfileSetupView: View {
             TabBarView(currentStep: currentStep)
                 .padding(.horizontal, 16)
 
-            TabView(selection: $currentStep) {
-                nicknameView.tag(SetupStep.nickname)
-
-                genderView.tag(SetupStep.gender)
-
-                birthdayView.tag(SetupStep.birthday)
+            Group {
+                switch currentStep {
+                case .nickname:
+                    nicknameView
+                case .gender:
+                    genderView
+                case .birthday:
+                    birthdayView
+                }
             }
             .padding(.horizontal, 24)
+
+            Spacer()
 
             actionButton
         }
@@ -71,8 +76,6 @@ extension InitProfileSetupView {
                     .font(.callout)
                     .padding(.leading, 4)
             }
-
-            Spacer()
         }
     }
 
@@ -92,8 +95,6 @@ extension InitProfileSetupView {
                     .buttonStyle(SelectableButtonStyle(isSelected: viewModel.isSelectedGender(gender)))
                 }
             }
-
-            Spacer()
         }
         .sensoryFeedback(.selection, trigger: viewModel.gender)
     }
@@ -106,8 +107,6 @@ extension InitProfileSetupView {
                 .bold()
 
             DatePicker("", selection: $viewModel.birthday, displayedComponents: .date)
-
-            Spacer()
         }
     }
 

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -84,11 +84,20 @@ extension InitProfileSetupView {
                 .font(.title)
                 .bold()
 
-            DateInputField(date: $viewModel.birthday) { date in
-                let formatter = DateFormatter()
-                formatter.locale = Locale(identifier: "ja_JP") // 日本語ロケール
-                formatter.dateStyle = .long
-                return formatter.string(from: date)
+            VStack(alignment: .leading, spacing: 16) {
+                DateInputField(date: $viewModel.birthday) { date in
+                    let formatter = DateFormatter()
+                    formatter.locale = Locale(identifier: "ja_JP") // 日本語ロケール
+                    formatter.dateStyle = .long
+                    return formatter.string(from: date)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Text("エラーが発生しました")
+                        .foregroundColor(.red)
+                        .font(.callout)
+                        .padding(.horizontal, 8)
+                }
             }
         }
     }

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -11,15 +11,14 @@ import SwiftUI
 struct InitProfileSetupView: View {
     
     @ObservedObject var viewModel: InitProfileSetupViewModel
-    @State private var currentStep: SetupStep = .nickname
     
     var body: some View {
         VStack(spacing: 36) {
-            TabBarView(currentStep: currentStep)
+            CustomTabBar(items: viewModel.setupSteps, currentItem: viewModel.currentStep)
                 .padding(.horizontal, 16)
 
             Group {
-                switch currentStep {
+                switch viewModel.currentStep {
                 case .nickname:
                     nicknameView
                 case .gender:
@@ -35,26 +34,6 @@ struct InitProfileSetupView: View {
             actionButton
         }
         .padding(.vertical, 24)
-    }
-}
-
-// MARK: - Setup Step
-extension InitProfileSetupView {
-    enum SetupStep: CaseIterable {
-        case nickname
-        case gender
-        case birthday
-
-        var nextStep: SetupStep? {
-            switch self {
-            case .nickname:
-                return    .gender
-            case .gender:
-                return   .birthday
-            case .birthday:
-                return nil
-            }
-        }
     }
 }
 
@@ -113,9 +92,9 @@ extension InitProfileSetupView {
     // TODO: disable対応
     private var actionButton: some View {
         Group {
-            if let nextStep = currentStep.nextStep {
+            if let nextStep = viewModel.currentStep.nextStep {
                 Button {
-                    self.currentStep = nextStep
+                    viewModel.toNextStep(nextStep)
                 } label: {
                     Text("次へ")
                 }
@@ -130,48 +109,6 @@ extension InitProfileSetupView {
         .buttonStyle(PrimaryButtonStyle())
     }
 }
-
-// MARK: - Tab Bar
-extension InitProfileSetupView {
-    struct TabBarView: View {
-
-        let currentStep: SetupStep
-        @Namespace var namespace
-
-        var body: some View {
-            HStack(alignment: .bottom) {
-                ForEach(SetupStep.allCases, id: \.self) { step in
-                    TabBarItem(step: step,
-                               currentStep: currentStep,
-                               namespace: namespace)
-                }
-            }
-        }
-    }
-
-    struct TabBarItem: View {
-
-        let step: SetupStep
-        let currentStep: SetupStep
-        let namespace: Namespace.ID
-
-        var body: some View {
-            ZStack {
-                Color(.systemGray4)
-
-                if currentStep == step {
-                    Color.main
-                        .matchedGeometryEffect(id: "line",
-                                               in: namespace,
-                                               properties: .frame)
-                }
-            }
-            .frame(height: 2)
-            .animation(.spring(), value: currentStep)
-        }
-    }
-}
-
 
 #Preview {
     InitProfileSetupView(

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -17,22 +17,24 @@ struct InitProfileSetupView: View {
             CustomTabBar(items: viewModel.setupSteps, currentItem: viewModel.currentStep)
                 .padding(.horizontal, 16)
 
-            Group {
-                switch viewModel.currentStep {
-                case .nickname:
-                    nicknameView
-                case .gender:
-                    genderView
-                case .birthday:
-                    birthdayView
+            VStack(spacing: 0) {
+                Group {
+                    switch viewModel.currentStep {
+                    case .nickname:
+                        nicknameView
+                    case .gender:
+                        genderView
+                    case .birthday:
+                        birthdayView
+                    }
                 }
-            }
-            .padding(.horizontal, 24)
-
-            Spacer()
-
-            actionButton
                 .padding(.horizontal, 24)
+
+                Spacer()
+
+                actionButton
+                    .padding(.horizontal, 24)
+            }
         }
         .padding(.vertical, 24)
     }

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -93,7 +93,7 @@ extension InitProfileSetupView {
                 }
 
                 if let errorMessage = viewModel.errorMessage {
-                    Text("エラーが発生しました")
+                    Text(errorMessage)
                         .foregroundColor(.red)
                         .font(.callout)
                         .padding(.horizontal, 8)

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -91,6 +91,8 @@ extension InitProfileSetupView {
                     formatter.dateStyle = .long
                     return formatter.string(from: date)
                 }
+                .bold()
+                .fieldBackground()
 
                 if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)

--- a/gymroutine-mobile/Views/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Views/InitProfileSetupView.swift
@@ -11,44 +11,168 @@ import SwiftUI
 struct InitProfileSetupView: View {
     
     @ObservedObject var viewModel: InitProfileSetupViewModel
+    @State private var currentStep: SetupStep = .nickname
     
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("追加情報を入力してください")
-                    .font(.title)
-                    .padding(.bottom, 16)
+        VStack(spacing: 36) {
+            TabBarView(currentStep: currentStep)
+                .padding(.horizontal, 16)
 
-                TextField("名前", text: $viewModel.name)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            TabView(selection: $currentStep) {
+                nicknameView.tag(SetupStep.nickname)
 
-                TextField("年齢", value: $viewModel.age, formatter: NumberFormatter())
-                    .keyboardType(.numberPad)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                genderView.tag(SetupStep.gender)
 
-                TextField("性別 (例: 男性/女性)", text: $viewModel.gender)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                DatePicker("生年月日", selection: $viewModel.birthday, displayedComponents: .date)
-                    .datePickerStyle(GraphicalDatePickerStyle())
-
-                Spacer()
-
-                Button(action: {
-                    viewModel.saveAdditionalInfo()
-                }) {
-                    Text("登録完了")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
+                birthdayView.tag(SetupStep.birthday)
             }
-            .padding()
+            .padding(.horizontal, 24)
+
+            actionButton
+        }
+        .padding(.vertical, 24)
+    }
+}
+
+// MARK: - Setup Step
+extension InitProfileSetupView {
+    enum SetupStep: CaseIterable {
+        case nickname
+        case gender
+        case birthday
+
+        var nextStep: SetupStep? {
+            switch self {
+            case .nickname:
+                return    .gender
+            case .gender:
+                return   .birthday
+            case .birthday:
+                return nil
+            }
         }
     }
 }
+
+// MARK: - Views
+extension InitProfileSetupView {
+    private var nicknameView: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            Text("ニックネームを入力してください")
+                .font(.title)
+                .bold()
+
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("入力してください", text: $viewModel.name)
+                    .fieldBackground()
+                    .submitLabel(.done)
+
+                Text("後から変更できます")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .padding(.leading, 4)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var genderView: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            Text("性別を教えてください")
+                .font(.title)
+                .bold()
+
+            VStack(spacing: 16) {
+                ForEach(InitProfileSetupViewModel.Gender.allCases, id: \.self) { gender in
+                    Button {
+                        viewModel.selectGender(gender)
+                    } label: {
+                        Text(gender.displeyText)
+                    }
+                    .buttonStyle(SelectableButtonStyle(isSelected: viewModel.isSelectedGender(gender)))
+                }
+            }
+
+            Spacer()
+        }
+        .sensoryFeedback(.selection, trigger: viewModel.gender)
+    }
+
+    // TODO: OTP風の入力にする
+    private var birthdayView: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            Text("生年月日を教えてください")
+                .font(.title)
+                .bold()
+
+            DatePicker("", selection: $viewModel.birthday, displayedComponents: .date)
+
+            Spacer()
+        }
+    }
+
+    // TODO: disable対応
+    private var actionButton: some View {
+        Group {
+            if let nextStep = currentStep.nextStep {
+                Button {
+                    self.currentStep = nextStep
+                } label: {
+                    Text("次へ")
+                }
+            } else {
+                Button {
+                    viewModel.saveAdditionalInfo()
+                } label: {
+                    Text("登録する")
+                }
+            }
+        }
+        .buttonStyle(PrimaryButtonStyle())
+    }
+}
+
+// MARK: - Tab Bar
+extension InitProfileSetupView {
+    struct TabBarView: View {
+
+        let currentStep: SetupStep
+        @Namespace var namespace
+
+        var body: some View {
+            HStack(alignment: .bottom) {
+                ForEach(SetupStep.allCases, id: \.self) { step in
+                    TabBarItem(step: step,
+                               currentStep: currentStep,
+                               namespace: namespace)
+                }
+            }
+        }
+    }
+
+    struct TabBarItem: View {
+
+        let step: SetupStep
+        let currentStep: SetupStep
+        let namespace: Namespace.ID
+
+        var body: some View {
+            ZStack {
+                Color(.systemGray4)
+
+                if currentStep == step {
+                    Color.main
+                        .matchedGeometryEffect(id: "line",
+                                               in: namespace,
+                                               properties: .frame)
+                }
+            }
+            .frame(height: 2)
+            .animation(.spring(), value: currentStep)
+        }
+    }
+}
+
 
 #Preview {
     InitProfileSetupView(

--- a/gymroutine-mobile/Views/LoginView.swift
+++ b/gymroutine-mobile/Views/LoginView.swift
@@ -38,7 +38,7 @@ struct LoginView: View {
             Button(action: {
                 viewModel.login()
             }) {
-                Text("ログイン")
+                Text("ログインする")
             }
             .buttonStyle(PrimaryButtonStyle())
         }

--- a/gymroutine-mobile/Views/LoginView.swift
+++ b/gymroutine-mobile/Views/LoginView.swift
@@ -13,14 +13,23 @@ struct LoginView: View {
     @State private var isShowingPasswordReset = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .center, spacing: 0) {
             InputForm
+
+            Button(action: {
+                isShowingPasswordReset = true
+            }) {
+                Text("パスワードを忘れた方はこちら")
+                    .font(.callout)
+                    .foregroundColor(.blue)
+            }
+            .padding(.vertical, 16)
+            .hAlign(.leading)
 
             if let errorMessage = viewModel.errorMessage {
                 Text(errorMessage)
                     .foregroundColor(.red)
-                    .padding(.top, 8)
-                    .padding(.leading, 4)
+                    .hAlign(.leading)
             }
 
             Spacer()
@@ -29,27 +38,17 @@ struct LoginView: View {
             Button(action: {
                 viewModel.login()
             }) {
-                Image(systemName: "chevron.forward")
+                Text("ログイン")
             }
-            .buttonStyle(CircleButtonStyle())
-            .hAlign(.trailing)
-
-            Button(action: {
-                isShowingPasswordReset = true
-            }) {
-                Text("パスワードを忘れた方はこちら")
-                    .font(.footnote)
-                    .foregroundColor(.blue)
-                    .padding(.top, 8)
-            }
-            .sheet(isPresented: $isShowingPasswordReset) {
-                PasswordResetView()
-            }
+            .buttonStyle(PrimaryButtonStyle())
         }
         .padding(.bottom, 16)
         .padding([.top, .horizontal], 24)
         .navigationTitle("ログイン")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isShowingPasswordReset) {
+            PasswordResetView()
+        }
     }
 
     private var InputForm: some View {

--- a/gymroutine-mobile/Views/PasswordResetView.swift
+++ b/gymroutine-mobile/Views/PasswordResetView.swift
@@ -1,48 +1,79 @@
 import SwiftUI
 
 struct PasswordResetView: View {
+
     @StateObject private var viewModel = PasswordResetViewModel(authService: AuthService())
 
     var body: some View {
-        VStack(spacing: 20) {
-            Text("パスワードリセット")
-                .font(.largeTitle)
-                .fontWeight(.bold)
+        NavigationStack {
+            VStack(spacing: 0) {
+                VStack(spacing: 56) {
+                    InputForm
 
-            TextField("メールアドレスを入力してください", text: $viewModel.email)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .keyboardType(.emailAddress)
-                .autocapitalization(.none)
-                .padding()
+                    VStack(spacing: 16) {
+                        sendResetLinkButton
 
-            DatePicker("生年月日を選択してください", selection: $viewModel.birthday, displayedComponents: .date)
+                        resetStatusMessage
+                    }
+                }
 
-            // エラーメッセージ表示
+                Spacer()
+            }
+            .padding(.bottom, 16)
+            .padding([.top, .horizontal], 24)
+            .navigationTitle("パスワードのリセット")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var InputForm: some View {
+        VStack(alignment: .center, spacing: 40) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("メールアドレス")
+                    .fontWeight(.semibold)
+
+                EmailAddressField(text: $viewModel.email)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("生年月日を選択してください")
+                    .fontWeight(.semibold)
+
+                DateInputField(date: $viewModel.birthday) { date in
+                    let formatter = DateFormatter()
+                    formatter.locale = Locale(identifier: "ja_JP") // 日本語ロケール
+                    formatter.dateStyle = .long
+                    return formatter.string(from: date)
+                }
+                .bold()
+                .fieldBackground()
+            }
+        }
+    }
+
+    private var sendResetLinkButton: some View {
+        Button(action: {
+            viewModel.sendPasswordReset()
+        }) {
+            Text("リセットリンクを送信")
+        }
+        .buttonStyle(PrimaryButtonStyle())
+    }
+
+    private var resetStatusMessage: some View {
+        Group {
             if let errorMessage = viewModel.errorMessage {
                 Text(errorMessage)
                     .foregroundColor(.red)
-                    .font(.caption)
-            }
-
-            Button(action: {
-                viewModel.sendPasswordReset()
-            }) {
-                Text("リセットリンクを送信")
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(8)
-            }
-
-            if viewModel.isResetLinkSent {
+            } else if viewModel.isResetLinkSent {
                 Text("リセットリンクを送信しました。メールを確認してください。")
                     .foregroundColor(.green)
-                    .font(.caption)
             }
-
-            Spacer()
         }
-        .padding()
+        .font(.callout)
     }
+}
+
+#Preview {
+    PasswordResetView()
 }

--- a/gymroutine-mobile/Views/SignupView.swift
+++ b/gymroutine-mobile/Views/SignupView.swift
@@ -31,9 +31,10 @@ struct SignupView: View {
                     }
                 }
             }) {
-                Text("新規登録する")
+                Image(systemName: "chevron.forward")
             }
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(CircleButtonStyle())
+            .hAlign(.trailing)
         }
         .padding(.bottom, 16)
         .padding([.top, .horizontal], 24)

--- a/gymroutine-mobile/Views/SignupView.swift
+++ b/gymroutine-mobile/Views/SignupView.swift
@@ -11,7 +11,7 @@ struct SignupView: View {
     @ObservedObject var viewModel: SignupViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .center, spacing: 0) {
             InputForm
 
             if let errorMessage = viewModel.errorMessage {
@@ -19,29 +19,21 @@ struct SignupView: View {
                     .foregroundColor(.red)
                     .padding(.top, 8)
                     .padding(.leading, 4)
+                    .hAlign(.leading)
             }
 
             Spacer()
 
-            HStack(spacing: 0) {
-                Spacer()
-
-                Button(action: {
-                    viewModel.signupWithEmailAndPassword { success in
-                        if success {
-                            viewModel.router.switchRootView(to: .initProfileSetup)
-                        }
+            Button(action: {
+                viewModel.signupWithEmailAndPassword { success in
+                    if success {
+                        viewModel.router.switchRootView(to: .initProfileSetup)
                     }
-                }) {
-                    Text("次へ")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
                 }
-                .buttonStyle(PlainButtonStyle())
+            }) {
+                Text("新規登録する")
             }
+            .buttonStyle(PrimaryButtonStyle())
         }
         .padding(.bottom, 16)
         .padding([.top, .horizontal], 24)


### PR DESCRIPTION
## 概要
以下の画面のUI実装 #11 
- プロフィール初期設定画面
- パスワードを探す画面

<details>
  <summary>変更後のUI</summary>

|ニックネーム|性別|誕生日|
|---|---|---|
|![simulator_screenshot_E296639F-E521-4EBC-A010-3CF56C55BA49](https://github.com/user-attachments/assets/2d484c74-5f30-4975-bec9-543e478866af)|![simulator_screenshot_5EA06D17-52B5-433C-AF0B-67744747B496](https://github.com/user-attachments/assets/74d03fc6-9f2a-4a37-a905-96c45d7431b5)|![simulator_screenshot_EAD43F17-68A4-4A8B-8575-24615801F182](https://github.com/user-attachments/assets/48fa6cdf-1595-420f-a542-6f83b00bc970)|

|ログイン画面|パスワードを探す画面|
|---|---|
|![simulator_screenshot_0BDEDF50-F82E-474A-B81F-58E816E059AB](https://github.com/user-attachments/assets/f3d16f96-6235-46f1-b0cf-ca26efc3af03)|![simulator_screenshot_73047A10-469A-41B8-831A-C6394EC7A77B](https://github.com/user-attachments/assets/cc2f09d9-d905-46ca-b9a8-5f561b037f36)|

</details>

## UI以外の変更点
- プロフィール初期設定画面
  - 性別：```enum gender```（```男性、女性、無回答```）
  - 誕生日の初期値: 2000年1月1日
- パスワードを探す画面
  - 誕生日の初期値: 2000年1月1日

## TODO
- ローディングの処理とUI
