### PR TITLE
Ishii/feat sp9 4 monthly calendar

### DIFF
--- a/gymroutine-mobile/Extensions/Array+Extensions.swift
+++ b/gymroutine-mobile/Extensions/Array+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  Array+Extensions.swift
+//  gymroutine-mobile
+//  
+//  Created by SATTSAT on 2025/02/05
+//  
+//
+
+extension Array {
+    //配列を分割する・例：[1,2,3,4,5,6](sizeが2だった場合) -> [[1,2],[3,4],[5.6]]
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/gymroutine-mobile/Extensions/Date+Extensions.swift
+++ b/gymroutine-mobile/Extensions/Date+Extensions.swift
@@ -1,0 +1,47 @@
+//
+//  Date+Extensions.swift
+//  gymroutine-mobile
+//  
+//  Created by SATTSAT on 2025/02/03
+//  
+//
+
+import Foundation
+
+extension Date {
+    //対象の月の日付情報を取得
+    func generateCalendarDays() -> [Date?] {
+        let calendar = Calendar.current
+        let firstDayOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: self))!
+        let firstWeekday = calendar.component(.weekday, from: firstDayOfMonth) - 1
+        let range = calendar.range(of: .day, in: .month, for: firstDayOfMonth)!
+
+        var days: [Date?] = Array(repeating: nil, count: firstWeekday)
+        for day in range {
+            days.append(calendar.date(byAdding: .day, value: day - 1, to: firstDayOfMonth))
+        }
+        return days
+    }
+    
+    // 同じ日付か判定
+    func isSameDay(as otherDate: Date) -> Bool {
+        let calendar = Calendar.current
+        return calendar.isDate(self, equalTo: otherDate, toGranularity: .day)
+    }
+    
+    // Stringに変換・出力例：2025年2月
+    func toYearMonthString() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy年M月"
+        return formatter.string(from: self)
+    }
+    
+    // Stringに変換・出力例：2月3日（月）
+    func toMonthDayWeekdayString() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "M月d日（EEE）"
+        return formatter.string(from: self)
+    }
+}

--- a/gymroutine-mobile/Manager/UserManager.swift
+++ b/gymroutine-mobile/Manager/UserManager.swift
@@ -48,6 +48,8 @@ class UserManager: ObservableObject {
             profilePhoto: data["profilePhoto"] as? String ?? "",
             visibility: data["visibility"] as? Int ?? 2,
             isActive: data["isActive"] as? Bool ?? false,
+            birthday: (data["birthday"] as? Timestamp)?.dateValue(),
+            gender: data["gender"] as? String ?? "",
             createdAt: (data["createdAt"] as? Timestamp)?.dateValue() ?? Date()
         )
     }

--- a/gymroutine-mobile/Models/UserModel.swift
+++ b/gymroutine-mobile/Models/UserModel.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-// TODO1: have to add birthday & gender
-
 struct User: Decodable {
     var uid: String
     var email: String
@@ -16,5 +14,7 @@ struct User: Decodable {
     var profilePhoto: String = ""
     var visibility: Int = 2 // 0: 非公開, 1: 友達公開, 2: 全体公開
     var isActive: Bool = false // 運動中なのか
+    var birthday: Date? = nil // birthday
+    var gender: String = "" // gender
     var createdAt: Date = Date()
 }

--- a/gymroutine-mobile/Services/AuthService.swift
+++ b/gymroutine-mobile/Services/AuthService.swift
@@ -69,6 +69,8 @@ class AuthService {
                 "profilePhoto": user.profilePhoto,
                 "visibility": user.visibility,
                 "isActive": user.isActive,
+                "birthday": user.birthday,
+                "gender": user.gender,
                 "createdAt": Timestamp(date: user.createdAt)
             ]
             try await documentRef.setData(userData, merge: true)

--- a/gymroutine-mobile/Services/AuthService.swift
+++ b/gymroutine-mobile/Services/AuthService.swift
@@ -74,6 +74,10 @@ class AuthService {
                 "createdAt": Timestamp(date: user.createdAt)
             ]
             try await documentRef.setData(userData, merge: true)
+            
+            // Initialize UserManager after saving
+            try await UserManager.shared.initializeUser()
+            
             return .success(())
         } catch {
             return .failure((NSError(domain: "SaveUserError", code: -1, userInfo: [NSLocalizedDescriptionKey: "User saved failed"])))

--- a/gymroutine-mobile/ViewModels/CalendarViewModel.swift
+++ b/gymroutine-mobile/ViewModels/CalendarViewModel.swift
@@ -7,7 +7,55 @@
 //
 
 import Foundation
+import SwiftUI
 
 final class CalendarViewModel: ObservableObject {
     
+    @Published var months: [Date] = []  //月ごとのDate情報
+    @Published var selectedDate: Date = Date()  //選択されている日にち
+    @Published var selectedMonth: Date? //Viewに表示されている月
+    
+    private let calendar: Calendar = .current
+    
+    init() {
+        self.months = (-2...2).compactMap { calendar.date(byAdding: .month, value: $0, to: selectedDate) }
+        self.selectedMonth = selectedDate
+    }
+    
+    //カレンダーがスクロールすると呼び出される
+    func onChangeMonth(_ month: Date?) {
+        guard let month = month else { return }
+        
+        print("[DEBUG] ここで「\(month.formatted(.dateTime.year().month()))」のDB取得ロジックを呼び出し")
+        checkAndLoadMoreMonths(for: month)
+    }
+    
+    // スクロール時に前後2ヶ月が確保されるように管理
+    func checkAndLoadMoreMonths(for monthDate: Date) {
+        if let firstIndex = months.firstIndex(of: monthDate),
+           firstIndex == 1 { // 先頭から2番目が表示されたら先月を追加
+            loadPreviousMonth()
+        }
+        
+        if let lastIndex = months.firstIndex(of: monthDate),
+           lastIndex == months.count - 2 { // 末尾から2番目が表示されたら翌月を追加
+            loadNextMonth()
+        }
+    }
+    
+    // months配列に先月を追加
+    func loadPreviousMonth() {
+        if let firstMonth = months.first,
+           let prevMonth = calendar.date(byAdding: .month, value: -1, to: firstMonth) {
+            months.insert(prevMonth, at: 0)
+        }
+    }
+
+    // months配列に来月を追加
+    func loadNextMonth() {
+        if let lastMonth = months.last,
+           let nextMonth = calendar.date(byAdding: .month, value: 1, to: lastMonth) {
+            months.append(nextMonth)
+        }
+    }
 }

--- a/gymroutine-mobile/ViewModels/CalendarViewModel.swift
+++ b/gymroutine-mobile/ViewModels/CalendarViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  CalendarViewModel.swift
+//  gymroutine-mobile
+//  
+//  Created by SATTSAT on 2025/02/03
+//  
+//
+
+import Foundation
+
+final class CalendarViewModel: ObservableObject {
+    
+}

--- a/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/ViewModels/InitProfileSetupViewModel.swift
@@ -48,6 +48,8 @@ final class InitProfileSetupViewModel: ObservableObject {
             profilePhoto: "",
             visibility: 2,
             isActive: false,
+            birthday: self.birthday,
+            gender: self.gender,
             createdAt: Date()
         )
         

--- a/gymroutine-mobile/Views/CalendarView.swift
+++ b/gymroutine-mobile/Views/CalendarView.swift
@@ -1,0 +1,47 @@
+//
+//  CalendarView.swift
+//  gymroutine-mobile
+//
+//  Created by 조성화 on 2024/12/27.
+//
+
+import Foundation
+import SwiftUI
+
+// TODO : 仮のカレンダビュー
+
+struct CalendarView: View {
+    var body: some View {
+        VStack {
+            Text("カレンダー")
+                .font(.title)
+                .padding()
+
+            List {
+                ForEach(generateDatesForCurrentMonth(), id: \.self) { date in
+                    Text(formatDate(date))
+                }
+            }
+        }
+        .navigationTitle("Calendar")
+    }
+
+    private func generateDatesForCurrentMonth() -> [Date] {
+        let calendar = Calendar.current
+        let today = Date()
+        let range = calendar.range(of: .day, in: .month, for: today)!
+
+        return range.compactMap { day -> Date? in
+            var components = calendar.dateComponents([.year, .month], from: today)
+            components.day = day
+            return calendar.date(from: components)
+        }
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter.string(from: date)
+    }
+}

--- a/gymroutine-mobile/Views/CalendarView.swift
+++ b/gymroutine-mobile/Views/CalendarView.swift
@@ -13,37 +13,130 @@ import SwiftUI
 struct CalendarView: View {
     
     @StateObject private var viewModel = CalendarViewModel()
+    @State private var routineFlg = false
+    
+    private let weekdays = ["日", "月", "火", "水", "木", "金", "土"]
+    
     var body: some View {
-        VStack {
-            Text("カレンダー")
-                .font(.title)
-                .padding()
+        VStack(spacing: 0) {
+            headerBox()
+            
+            calendarBox
+            
+            contentBox
+        }
+        .background(Color.gray.opacity(0.1))
+        .sheet(isPresented: $routineFlg) {
+            Text("ルーティーン追加画面を\nここに作成")
+        }
+    }
+}
 
-            List {
-                ForEach(generateDatesForCurrentMonth(), id: \.self) { date in
-                    Text(formatDate(date))
+//MARK: Views
+extension CalendarView {
+    @ViewBuilder
+    private func headerBox() -> some View {
+        if let selectedMonth = viewModel.selectedMonth {
+            Text(selectedMonth.toYearMonthString())
+                .font(.title2.bold())
+                .padding()
+                .hAlign(.center)
+                .overlay(alignment: .trailing) {
+                    Button(action: {
+                        routineFlg.toggle()
+                    }, label: {
+                        Image(systemName: "plus")
+                            .imageScale(.large).bold()
+                            .padding(.trailing)
+                    })
+                }
+        }
+    }
+    
+    private var calendarBox: some View {
+        VStack {
+            
+            LazyVGrid(columns: Array(repeating: GridItem(), count: 7)) {
+                ForEach(weekdays, id: \.self) { weekday in
+                    Text(weekday)
+                        .fontWeight(.bold)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            
+            Divider()
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 0) {
+                    ForEach(viewModel.months, id: \.self) { month in
+                        CalendarGridView(month.generateCalendarDays())
+                            .containerRelativeFrame([.horizontal, .vertical])
+                            .id(month)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: $viewModel.selectedMonth)
+            .vAlign(.center)
+            .onChange(of: viewModel.selectedMonth) {
+                viewModel.onChangeMonth(viewModel.selectedMonth)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func CalendarGridView(_ days: [Date?]) -> some View {
+        VStack(spacing: 4) {
+            ForEach(Array(days.chunked(into: 7)), id: \.self) { week in
+                HStack(spacing: 4) {
+                    ForEach(0..<7, id: \.self) { index in
+                        Group {
+                            if index < week.count, let validDay = week[index] {
+                                Text("\(Calendar.current.component(.day, from: validDay))")
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(validDay.isSameDay(as: viewModel.selectedDate) ? .main : .clear, lineWidth: 2)
+                                    )
+                                    .onTapGesture {
+                                        viewModel.selectedDate = validDay
+                                    }
+                            } else {
+                                Rectangle()
+                                    .fill(Color.clear)
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            }
+                        }
+                        .padding(2)
+                    }
                 }
             }
         }
-        .navigationTitle("Calendar")
+        .vAlign(.center)
     }
-
-    private func generateDatesForCurrentMonth() -> [Date] {
-        let calendar = Calendar.current
-        let today = Date()
-        let range = calendar.range(of: .day, in: .month, for: today)!
-
-        return range.compactMap { day -> Date? in
-            var components = calendar.dateComponents([.year, .month], from: today)
-            components.day = day
-            return calendar.date(from: components)
+    
+    private var contentBox: some View {
+        VStack {
+            Text(viewModel.selectedDate.toMonthDayWeekdayString())
+                .font(.headline)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .hAlign(.leading)
+                .background(Color.gray.opacity(0.2))
+            
+            ScrollView(showsIndicators: false) {
+                VStack {
+                    Text("ここにWorkoutCellを配置")
+                    Text("ここにWorkoutCellを配置")
+                    Text("ここにWorkoutCellを配置")
+                }
+            }
+            .vAlign(.top)
         }
     }
+}
 
-    private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .long
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter.string(from: date)
-    }
+#Preview {
+    CalendarView()
 }

--- a/gymroutine-mobile/Views/CalendarView.swift
+++ b/gymroutine-mobile/Views/CalendarView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 // TODO : 仮のカレンダビュー
 
 struct CalendarView: View {
+    
+    @StateObject private var viewModel = CalendarViewModel()
     var body: some View {
         VStack {
             Text("カレンダー")

--- a/gymroutine-mobile/Views/HomeView.swift
+++ b/gymroutine-mobile/Views/HomeView.swift
@@ -1,0 +1,34 @@
+//
+//  HomeView.swift
+//  gymroutine-mobile
+//
+//  Created by 조성화 on 2024/12/27.
+//
+
+import Foundation
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var userManager: UserManager
+    @ObservedObject var viewModel: MainViewModel
+    
+    var body: some View {
+        VStack {
+            if let email = userManager.currentUser?.email {
+                Text("\(email)でログインしました！")
+                    .font(.headline)
+            } else {
+                Text("ユーザー情報がありません")
+                    .font(.headline)
+            }
+            
+            Button {
+                viewModel.logout()
+            } label: {
+                Text("ログアウトするよ")
+            }
+        }
+        .padding()
+        .navigationTitle("Home")
+    }
+}

--- a/gymroutine-mobile/Views/MainView.swift
+++ b/gymroutine-mobile/Views/MainView.swift
@@ -27,12 +27,18 @@ struct MainView: View {
                     Label("Calendar", systemImage: "calendar")
                 }
                 .tag(1)
-            
+
+            SnsView()
+                .tabItem {
+                    Label("SNS", systemImage: "magnifyingglass")
+                }
+                .tag(2)
+
             ProfileView()
                 .tabItem {
                     Label("Profile", systemImage: "person.circle")
                 }
-                .tag(2)
+                .tag(3)
         }
     }
 }

--- a/gymroutine-mobile/Views/MainView.swift
+++ b/gymroutine-mobile/Views/MainView.swift
@@ -11,23 +11,28 @@ import SwiftUI
 struct MainView: View {
     @ObservedObject var viewModel: MainViewModel
     @EnvironmentObject var userManager: UserManager
-    
-    var body: some View {
-        VStack {
-            
-                let email = userManager.currentUser?.email
-                
-                Text("\(email)でログインしました！")
-                    .font(.headline)
-                
-            
+    @State private var selectedTab: Int = 0 // 현재 선택된 탭
 
-            Button {
-                viewModel.logout()
-            } label: {
-                Text("ログアウトするよ")
-            }
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            HomeView(viewModel: viewModel)
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+                .tag(0)
+
+
+            CalendarView()
+                .tabItem {
+                    Label("Calendar", systemImage: "calendar")
+                }
+                .tag(1)
+            
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.circle")
+                }
+                .tag(2)
         }
     }
 }
-

--- a/gymroutine-mobile/Views/ProfileView.swift
+++ b/gymroutine-mobile/Views/ProfileView.swift
@@ -1,0 +1,28 @@
+//
+//  ProfileView.swift
+//  gymroutine-mobile
+//
+//  Created by 조성화 on 2024/12/27.
+//
+
+import Foundation
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject var userManager: UserManager
+
+    var body: some View {
+        VStack {
+            if let user = userManager.currentUser {
+                Text("Name: \(user.name)")
+                    .font(.title2)
+                Text("Email: \(user.email)")
+                    .font(.body)
+            } else {
+                Text("プロフィール情報がありません")
+            }
+        }
+        .padding()
+        .navigationTitle("Profile")
+    }
+}

--- a/gymroutine-mobile/Views/SnsView.swift
+++ b/gymroutine-mobile/Views/SnsView.swift
@@ -1,0 +1,18 @@
+//
+//  SnsView.swift
+//  gymroutine-mobile
+//
+//  Created by 森祐樹 on 2024/12/30.
+//
+
+import SwiftUI
+
+struct SnsView: View {
+    var body: some View {
+        Text("SNS View")
+    }
+}
+
+#Preview {
+    SnsView()
+}


### PR DESCRIPTION
## カレンダーViewの実装
### 実装したこと
- 2/1時点でのdevの内容をpullしました
- Dateの扱いを楽にするため、DateのExtensionを追加しました
- カレンダー表示をするため、ArrayのExtensionとして、配列を指定のsizeに分割するchunked関数を追加しました
- 月間カレンダーを表示するカレンダーViewを実装しました
- カレンダーViewの変数や処理を管理するViewModelを実装しました

### 補足
- カレンダーCellの初期選択はその日が選択されるようにしています
- 月間カレンダーがスクロールされた時（翌月、先月に移動した時）に、viewModelの「onChangeMonth」が呼ばれます
- 月間カレンダーを管理する変数「months」は、スクロールすることで追加ロードされる仕組みです

### スクリーンショット
| CalendarView   |
|------------|
| <img src="https://github.com/user-attachments/assets/ebe3463c-854e-4889-95cb-aff00d8b0a27" alt="IMG_3472" width="300px" />  |  |

### 改善事項
- Workoutモデルを実装時にFirebaseから取得するロジックを実装する
- 画面右上のルーティーン追加ボタンを押した際のViewをCreateRoutineViewに差し替え






