### PR TITLE
Ishii/feat sp9 4 fetch calendar data

### DIFF
--- a/gymroutine-mobile/Services/WorkoutService.swift
+++ b/gymroutine-mobile/Services/WorkoutService.swift
@@ -22,6 +22,30 @@ class WorkoutService {
         }
     }
     
+    func fetchUserWorkouts(uid: String) async -> [TestWorkout]? {
+        let db = Firestore.firestore()
+        let workoutsRef = db.collection("Workouts").whereField("uuid", isEqualTo: uid)
+
+        do {
+            let snapshot = try await workoutsRef.getDocuments()
+            var workouts: [TestWorkout] = []
+
+            for document in snapshot.documents {
+                do {
+                    let workout = try document.data(as: TestWorkout.self)
+                    workouts.append(workout)
+                } catch {
+                    print("[ERROR] Workoutのデコードエラー: \(error)")
+                }
+            }
+            return workouts
+
+        } catch {
+            print("[ERROR] Firestore 取得エラー: \(error)")
+            return nil
+        }
+    }
+    
     func fetchTrainOptions(completion: @escaping ([String]) -> Void) {
         let db = Firestore.firestore()
         db.collection("Trains").getDocuments { (snapshot, error) in

--- a/gymroutine-mobile/ViewModels/CalendarViewModel.swift
+++ b/gymroutine-mobile/ViewModels/CalendarViewModel.swift
@@ -8,7 +8,23 @@
 
 import Foundation
 import SwiftUI
+import FirebaseFirestore
 
+struct TestWorkout: Decodable {
+    @DocumentID var id: String?
+    let uuid: String
+    let name: String
+    let createdAt: Date
+    let scheduledDays: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case uuid
+        case name
+        case createdAt = "CreatedAt"
+        case scheduledDays = "ScheduledDays"
+    }
+}
 final class CalendarViewModel: ObservableObject {
     
     @Published var months: [Date] = []  //月ごとのDate情報

--- a/gymroutine-mobile/Views/CalendarView.swift
+++ b/gymroutine-mobile/Views/CalendarView.swift
@@ -93,15 +93,27 @@ extension CalendarView {
                     ForEach(0..<7, id: \.self) { index in
                         Group {
                             if index < week.count, let validDay = week[index] {
-                                Text("\(Calendar.current.component(.day, from: validDay))")
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .stroke(validDay.isSameDay(as: viewModel.selectedDate) ? .main : .clear, lineWidth: 2)
-                                    )
-                                    .onTapGesture {
-                                        viewModel.selectedDate = validDay
+                                let workouts = viewModel.getWorkoutsForWeekday(index: index)
+                                VStack {
+                                    Text("\(Calendar.current.component(.day, from: validDay))")
+                                    
+                                    HStack {
+                                        ForEach(0..<workouts.count, id: \.self) { _ in
+                                            Circle()
+                                                .fill(Color.red)
+                                                .frame(width: 6, height: 6)
+                                        }
                                     }
+                                    .frame(height: 6)
+                                }
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .stroke(validDay.isSameDay(as: viewModel.selectedDate) ? .main : .clear, lineWidth: 2)
+                                )
+                                .onTapGesture {
+                                    viewModel.selectedDate = validDay
+                                }
                             } else {
                                 Rectangle()
                                     .fill(Color.clear)
@@ -126,11 +138,23 @@ extension CalendarView {
                 .background(Color.gray.opacity(0.2))
             
             ScrollView(showsIndicators: false) {
-                VStack {
-                    Text("ここにWorkoutCellを配置")
-                    Text("ここにWorkoutCellを配置")
-                    Text("ここにWorkoutCellを配置")
+                VStack(spacing: 8) {
+                    let weekdayIndex = Calendar.current.component(.weekday, from: viewModel.selectedDate) - 1
+                    let workouts = viewModel.getWorkoutsForWeekday(index: weekdayIndex)
+                    
+                    if workouts.isEmpty {
+                        Text("ワークアウトなし")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(workouts, id: \.id) { workout in
+                            Text(workout.name)
+                                .font(.headline)
+                                .hAlign(.leading)
+                                .padding()
+                        }
+                    }
                 }
+                .padding()
             }
             .vAlign(.top)
         }


### PR DESCRIPTION
## カレンダーViewでのFirebaseからユーザーのワークアウト情報の取得・表示を実装
### 実装したこと
- 3月時点でのdevの内容をpullしました
- 指定したユーザーIDのスケジュール済みワークアウトを取得する処理をServiceに実装しました
- カレントユーザーのワークアウト情報を取得、曜日ごとにワークアウトを分類する処理をViewModelに実装しました
- Viewにスケジュールされたワークアウトを表示しました

### スクリーンショット
| CalendarView   |
|------------|
| <img src="https://github.com/user-attachments/assets/6c306d47-c730-4165-a80a-a9b30053caa3" alt="IMG_3472" width="300px" />  |  |

### 改善事項
- 現在SP9-4にはWorkoutモデルが存在しないため、「TestWorkout」モデルで代用しています。統合後、修正が必要
- 画面下にあるワークアウト情報のUIは、TestWorkoutを本番モデルに差し替え後に実装