### PR TITLE
Ishii/ローディング画面・バナー画面の実装

### DIFF
--- a/gymroutine-mobile.xcodeproj/project.pbxproj
+++ b/gymroutine-mobile.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		003AF5DA2D8BE9F60019B3AF /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003AF5D92D8BE9F60019B3AF /* UIApplication+Extensions.swift */; };
+		008769DF2D8BD5C400965C26 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008769DE2D8BD5C400965C26 /* LoadingView.swift */; };
 		009CE5D12D8AB5A800FD76FD /* EditExerciseSetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009CE5D02D8AB5A800FD76FD /* EditExerciseSetView.swift */; };
 		00CDC4252D845E8E003B18EB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00CDC3DB2D845E8E003B18EB /* Preview Assets.xcassets */; };
 		00CDC4262D845E8E003B18EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00CDC4222D845E8E003B18EB /* Assets.xcassets */; };
@@ -100,6 +102,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		003AF5D92D8BE9F60019B3AF /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
+		008769DE2D8BD5C400965C26 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		009CE5D02D8AB5A800FD76FD /* EditExerciseSetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditExerciseSetView.swift; sourceTree = "<group>"; };
 		00CDC3D02D845E8E003B18EB /* gymroutine_mobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gymroutine_mobileApp.swift; sourceTree = "<group>"; };
 		00CDC3D12D845E8E003B18EB /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
@@ -216,6 +220,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		008769DD2D8BD5B200965C26 /* OverlayViews */ = {
+			isa = PBXGroup;
+			children = (
+				008769DE2D8BD5C400965C26 /* LoadingView.swift */,
+			);
+			path = OverlayViews;
+			sourceTree = "<group>";
+		};
 		009CE5D82D8B226800FD76FD /* ExerciseSearch */ = {
 			isa = PBXGroup;
 			children = (
@@ -238,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				00CDC3D32D845E8E003B18EB /* View+Extensions.swift */,
+				003AF5D92D8BE9F60019B3AF /* UIApplication+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -353,6 +366,7 @@
 		00CDC4092D845E8E003B18EB /* ViewParts */ = {
 			isa = PBXGroup;
 			children = (
+				008769DD2D8BD5B200965C26 /* OverlayViews */,
 				00CDC3FD2D845E8E003B18EB /* Buttons */,
 				00CDC3FF2D845E8E003B18EB /* Cells */,
 				00CDC4042D845E8E003B18EB /* InputText */,
@@ -724,6 +738,7 @@
 				00CDC42A2D845E8E003B18EB /* View+Extensions.swift in Sources */,
 				00CDC42B2D845E8E003B18EB /* UserManager.swift in Sources */,
 				00CDC42C2D845E8E003B18EB /* ExcersiceModel.swift in Sources */,
+				008769DF2D8BD5C400965C26 /* LoadingView.swift in Sources */,
 				00CDC42D2D845E8E003B18EB /* UserModel.swift in Sources */,
 				00CDC42E2D845E8E003B18EB /* WorkoutModel.swift in Sources */,
 				00CDC42F2D845E8E003B18EB /* FollowRepository.swift in Sources */,
@@ -756,6 +771,7 @@
 				00CDC4492D845E8E003B18EB /* SecondaryButtonStyle.swift in Sources */,
 				00CDC44A2D845E8E003B18EB /* SecondaryCircleButtonStyle.swift in Sources */,
 				00CDC44B2D845E8E003B18EB /* SelectableButtonStyle.swift in Sources */,
+				003AF5DA2D8BE9F60019B3AF /* UIApplication+Extensions.swift in Sources */,
 				00CDC44C2D845E8E003B18EB /* WorkoutCell.swift in Sources */,
 				00CDC44D2D845E8E003B18EB /* DateInputField.swift in Sources */,
 				00CDC44E2D845E8E003B18EB /* EmailAddressField.swift in Sources */,

--- a/gymroutine-mobile.xcodeproj/project.pbxproj
+++ b/gymroutine-mobile.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		003AF5DA2D8BE9F60019B3AF /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003AF5D92D8BE9F60019B3AF /* UIApplication+Extensions.swift */; };
+		003AF5EB2D8BF2720019B3AF /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003AF5EA2D8BF2720019B3AF /* BannerView.swift */; };
 		008769DF2D8BD5C400965C26 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008769DE2D8BD5C400965C26 /* LoadingView.swift */; };
 		009CE5D12D8AB5A800FD76FD /* EditExerciseSetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009CE5D02D8AB5A800FD76FD /* EditExerciseSetView.swift */; };
 		00CDC4252D845E8E003B18EB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00CDC3DB2D845E8E003B18EB /* Preview Assets.xcassets */; };
@@ -103,6 +104,7 @@
 
 /* Begin PBXFileReference section */
 		003AF5D92D8BE9F60019B3AF /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
+		003AF5EA2D8BF2720019B3AF /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		008769DE2D8BD5C400965C26 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		009CE5D02D8AB5A800FD76FD /* EditExerciseSetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditExerciseSetView.swift; sourceTree = "<group>"; };
 		00CDC3D02D845E8E003B18EB /* gymroutine_mobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gymroutine_mobileApp.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 			isa = PBXGroup;
 			children = (
 				008769DE2D8BD5C400965C26 /* LoadingView.swift */,
+				003AF5EA2D8BF2720019B3AF /* BannerView.swift */,
 			);
 			path = OverlayViews;
 			sourceTree = "<group>";
@@ -741,6 +744,7 @@
 				008769DF2D8BD5C400965C26 /* LoadingView.swift in Sources */,
 				00CDC42D2D845E8E003B18EB /* UserModel.swift in Sources */,
 				00CDC42E2D845E8E003B18EB /* WorkoutModel.swift in Sources */,
+				003AF5EB2D8BF2720019B3AF /* BannerView.swift in Sources */,
 				00CDC42F2D845E8E003B18EB /* FollowRepository.swift in Sources */,
 				00CDC4302D845E8E003B18EB /* SnsRepository.swift in Sources */,
 				00CDC4312D845E8E003B18EB /* AuthService.swift in Sources */,

--- a/gymroutine-mobile/Extensions/UIApplication+Extensions.swift
+++ b/gymroutine-mobile/Extensions/UIApplication+Extensions.swift
@@ -13,6 +13,7 @@ import SwiftUI
 extension UIApplication {
     
     static var loadingWindow: UIWindow?
+    static var bannerWindow: UIWindow?
     
     //ローディングViewの表示
     static func showLoading(message: String? = nil) {
@@ -29,7 +30,47 @@ extension UIApplication {
         newWindow.makeKeyAndVisible()
     }
     
+    // ローディングViewの非表示
     static func hideLoading() {
         loadingWindow = nil
     }
+    
+    static func showBanner(type: BannerType, message: String) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else { return }
+        
+        let newWindow = TransparentTouchWindow(windowScene: windowScene)
+        let vc = UIHostingController(rootView: BannerView(type: type, message: message))
+        
+        vc.view.backgroundColor = .clear
+        newWindow.rootViewController = vc
+        newWindow.windowLevel = UIWindow.Level.alert + 1
+        UIApplication.loadingWindow = newWindow
+        newWindow.makeKeyAndVisible()
+    }
 }
+
+// View表示部分以外のタッチを有効可するカスタムUIWindow
+final class TransparentTouchWindow: UIWindow {
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event),
+              let rootView = rootViewController?.view else {
+                  return nil
+              }
+        
+        if #available(iOS 18, *) {
+            for subView in rootView.subviews.reversed() {
+                let pointInSubView = subView.convert(point, from: rootView)
+                if subView.hitTest(pointInSubView, with: event) == subView {
+                    return hitView
+                }
+            }
+            
+            return nil
+        } else {
+            return hitView == rootView ? nil : hitView
+        }
+    }
+}
+

--- a/gymroutine-mobile/Extensions/UIApplication+Extensions.swift
+++ b/gymroutine-mobile/Extensions/UIApplication+Extensions.swift
@@ -1,0 +1,35 @@
+//
+//  UIApplication+Extensions
+//  gymroutine-mobile
+//
+//  Created by SATTSAT on 2025/03/20
+//
+//
+
+import Foundation
+import UIKit
+import SwiftUI
+
+extension UIApplication {
+    
+    static var loadingWindow: UIWindow?
+    
+    //ローディングViewの表示
+    static func showLoading(message: String? = nil) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else { return }
+        
+        let newWindow = UIWindow(windowScene: windowScene)
+        let vc = UIHostingController(rootView: LoadingView(message: message))
+        
+        vc.view.backgroundColor = .clear
+        newWindow.rootViewController = vc
+        newWindow.windowLevel = UIWindow.Level.alert + 1
+        UIApplication.loadingWindow = newWindow
+        newWindow.makeKeyAndVisible()
+    }
+    
+    static func hideLoading() {
+        loadingWindow = nil
+    }
+}

--- a/gymroutine-mobile/Features/Home/HomeViewModel.swift
+++ b/gymroutine-mobile/Features/Home/HomeViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 @MainActor
 final class HomeViewModel: ObservableObject {
@@ -21,17 +22,17 @@ final class HomeViewModel: ObservableObject {
     /// 現在のユーザーがフォローしているユーザー一覧を読み込む
     func loadFollowingUsers() {
         Task {
+            UIApplication.showLoading()
             // UserManagerはグローバルなシングルトンとして現在のユーザー情報を管理している前提
             guard let currentUserID = UserManager.shared.currentUser?.uid else { return }
             let result = await snsService.getFollowingUsers(for: currentUserID)
             switch result {
             case .success(let users):
-                DispatchQueue.main.async {
-                    self.followingUsers = users
-                }
+                self.followingUsers = users
             case .failure(let error):
                 print("팔로잉ユーザーの読み込みに失敗しました: \(error.localizedDescription)")
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Features/Profile/ProfileViewModel.swift
+++ b/gymroutine-mobile/Features/Profile/ProfileViewModel.swift
@@ -78,15 +78,15 @@ final class ProfileViewModel: ObservableObject {
     /// フォロワーとフォロー中の数を読み込む
     /// - Parameter userId: ユーザーのUID
     private func loadFollowerAndFollowingCounts(userId: String) {
-        // ※ここでは UserManager 経由でのカウント取得処理を使っていますが、
-        //    必要に応じて FollowService 経由でフォロワー一覧やフォロー中一覧を取得し、数を更新することも可能です。
         Task {
+            UIApplication.showLoading()
             let followers = await userManager.fetchFollowersCount(userId: userId)
             let following = await userManager.fetchFollowingCount(userId: userId)
             DispatchQueue.main.async {
                 self.followersCount = followers
                 self.followingCount = following
             }
+            UIApplication.hideLoading()
         }
     }
     
@@ -94,12 +94,14 @@ final class ProfileViewModel: ObservableObject {
     /// - Parameter image: アップロードするUIImage
     func uploadProfilePhoto(_ image: UIImage) {
         Task {
+            UIApplication.showLoading()
             guard let userID = userManager.currentUser?.uid else { return }
             if let newProfileURL = await userService.uploadProfilePhoto(userID: userID, image: image) {
                 DispatchQueue.main.async {
                     self.user?.profilePhoto = newProfileURL
                 }
             }
+            UIApplication.hideLoading()
         }
     }
     
@@ -108,6 +110,7 @@ final class ProfileViewModel: ObservableObject {
     /// 現在ログイン中のユーザーがこのプロフィールを既にフォローしているか確認する
     func updateFollowingStatus() {
         Task {
+            UIApplication.showLoading()
             guard let currentUserID = userManager.currentUser?.uid,
                   let profileUserID = user?.uid,
                   currentUserID != profileUserID else { return }
@@ -115,12 +118,14 @@ final class ProfileViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self.isFollowing = status
             }
+            UIApplication.hideLoading()
         }
     }
     
     /// フォローする処理
     func follow() {
         Task {
+            UIApplication.showLoading()
             guard let currentUserID = userManager.currentUser?.uid,
                   let profileUserID = user?.uid,
                   currentUserID != profileUserID else { return }
@@ -131,12 +136,14 @@ final class ProfileViewModel: ObservableObject {
                     self.followersCount += 1
                 }
             }
+            UIApplication.hideLoading()
         }
     }
     
     /// フォロー解除する処理
     func unfollow() {
         Task {
+            UIApplication.showLoading()
             guard let currentUserID = userManager.currentUser?.uid,
                   let profileUserID = user?.uid,
                   currentUserID != profileUserID else { return }
@@ -147,6 +154,7 @@ final class ProfileViewModel: ObservableObject {
                     self.followersCount -= 1
                 }
             }
+            UIApplication.hideLoading()
         }
     }
     
@@ -154,11 +162,13 @@ final class ProfileViewModel: ObservableObject {
     /// - Parameter newItem: 変更後のPhotosPickerItem
     func handleSelectedPhotoItemChange(_ newItem: PhotosPickerItem?) {
         Task {
+            UIApplication.showLoading()
             if let newItem = newItem,
                let data = try? await newItem.loadTransferable(type: Data.self),
                let image = UIImage(data: data) {
                 self.uploadProfilePhoto(image)
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupView.swift
+++ b/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupView.swift
@@ -96,13 +96,6 @@ extension InitProfileSetupView {
                 }
                 .bold()
                 .fieldBackground()
-
-                if let errorMessage = viewModel.errorMessage {
-                    Text(errorMessage)
-                        .foregroundColor(.red)
-                        .font(.callout)
-                        .padding(.horizontal, 8)
-                }
             }
         }
     }

--- a/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import FirebaseAuth
 import Combine
+import SwiftUI
 
 @MainActor
 final class InitProfileSetupViewModel: ObservableObject {
@@ -59,7 +60,7 @@ final class InitProfileSetupViewModel: ObservableObject {
         )
         
         Task {
-            //ローディング画面表示
+            UIApplication.showLoading()
             let saveResult = await authService.saveUserInfo(user: user)
             switch saveResult {
             case .success(_):
@@ -67,7 +68,7 @@ final class InitProfileSetupViewModel: ObservableObject {
             case .failure(let error):
                 self.errorMessage = error.localizedDescription
             }
-            //ローディング画面非表示
+            UIApplication.hideLoading()
         }
     }
 

--- a/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupViewModel.swift
+++ b/gymroutine-mobile/Features/Root/InitProfileSetup/InitProfileSetupViewModel.swift
@@ -21,7 +21,6 @@ final class InitProfileSetupViewModel: ObservableObject {
     @Published var age: Int = 0
     @Published var gender: Gender? = nil
     @Published var birthday: Date = Date()
-    @Published var errorMessage: String? = nil
     @Published var isSignedUp: Bool = false
     @Published var currentStep: SetupStep = .nickname
 
@@ -66,7 +65,7 @@ final class InitProfileSetupViewModel: ObservableObject {
             case .success(_):
                 router.switchRootView(to: .main(user: user))
             case .failure(let error):
-                self.errorMessage = error.localizedDescription
+                UIApplication.showBanner(type: .error, message: error.localizedDescription)
             }
             UIApplication.hideLoading()
         }

--- a/gymroutine-mobile/Features/Root/Splash/SplashViewModel.swift
+++ b/gymroutine-mobile/Features/Root/Splash/SplashViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import FirebaseAuth
+import SwiftUI
 
 @MainActor
 final class SplashViewModel: ObservableObject {
@@ -29,7 +30,6 @@ final class SplashViewModel: ObservableObject {
         
         Task {
             await userManager.initializeUser()
-            //ローディングView表示
             let fetchResult = await authService.fetchUser(uid: currentUser.uid)
             switch fetchResult {
             case .success(let user):
@@ -38,7 +38,6 @@ final class SplashViewModel: ObservableObject {
                 print("[ERROR] \(error.localizedDescription)")
                 router.switchRootView(to: .initProfileSetup)
             }
-            //ローディングView非表示
         }
     }
 }

--- a/gymroutine-mobile/Features/Root/Welcome/Login/LoginView.swift
+++ b/gymroutine-mobile/Features/Root/Welcome/Login/LoginView.swift
@@ -25,13 +25,7 @@ struct LoginView: View {
             }
             .padding(.vertical, 16)
             .hAlign(.leading)
-
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .foregroundColor(.red)
-                    .hAlign(.leading)
-            }
-
+            
             Spacer()
 
             // TODO: disable対応

--- a/gymroutine-mobile/Features/Root/Welcome/Login/LoginViewModel.swift
+++ b/gymroutine-mobile/Features/Root/Welcome/Login/LoginViewModel.swift
@@ -6,11 +6,11 @@
 //
 import Foundation
 import Combine
+import SwiftUI
 
 class LoginViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
-    @Published var errorMessage: String? = nil
     
     private var cancellables = Set<AnyCancellable>()
     private let authService = AuthService()
@@ -25,16 +25,15 @@ class LoginViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
                 if case .failure(let error) = completion {
-                    self.errorMessage = error.localizedDescription
+                    UIApplication.showBanner(type: .error, message: error.localizedDescription)
                 }
             }, receiveValue: { user in
                 if let user = user {
-                    self.errorMessage = nil
                     DispatchQueue.main.async {
                         self.router.switchRootView(to: .main(user: user))
                     }
                 } else {
-                    self.errorMessage = "login failed"
+                    UIApplication.showBanner(type: .error, message: "login failed")
                 }
             })
             .store(in: &cancellables)

--- a/gymroutine-mobile/Features/Root/Welcome/Signup/SignupView.swift
+++ b/gymroutine-mobile/Features/Root/Welcome/Signup/SignupView.swift
@@ -14,14 +14,6 @@ struct SignupView: View {
         VStack(alignment: .center, spacing: 0) {
             InputForm
 
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .foregroundColor(.red)
-                    .padding(.top, 8)
-                    .padding(.leading, 4)
-                    .hAlign(.leading)
-            }
-
             Spacer()
 
             Button(action: {

--- a/gymroutine-mobile/Features/Root/Welcome/Signup/SignupViewModel.swift
+++ b/gymroutine-mobile/Features/Root/Welcome/Signup/SignupViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import SwiftUI
 
 class SignupViewModel: ObservableObject {
     @Published var email: String = ""
@@ -16,7 +17,6 @@ class SignupViewModel: ObservableObject {
     @Published var age: Int = 0
     @Published var gender: String = ""
     @Published var birthday: Date = Date()
-    @Published var errorMessage: String? = nil
     @Published var userUID: String? = nil
     @Published var isSignedUp: Bool = false
 
@@ -31,17 +31,17 @@ class SignupViewModel: ObservableObject {
     /// Firebase Authentication - create account
     func signupWithEmailAndPassword(completion: @escaping (Bool) -> Void) {
         guard password == confirmPassword else {
-            self.errorMessage = "Passwords do not match"
+            UIApplication.showBanner(type: .error, message: "パスワードが一致していません。")
             completion(false)
             return
         }
 
         authService.createUser(email: email, password: password)
             .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { [weak self] completionResult in
+            .sink(receiveCompletion: { completionResult in
                 switch completionResult {
                 case .failure(let error):
-                    self?.errorMessage = error.localizedDescription
+                    UIApplication.showBanner(type: .error, message: error.localizedDescription)
                     print("Error creating user: \(error.localizedDescription)")
                     completion(false)
                 case .finished:
@@ -50,7 +50,6 @@ class SignupViewModel: ObservableObject {
             }, receiveValue: { [weak self] userUID in
                 self?.userUID = userUID
                 print("User UID: \(userUID)") // 로그 추가
-                self?.errorMessage = nil
                 completion(true)
             })
             .store(in: &cancellables)

--- a/gymroutine-mobile/Features/Sns/SearchUser/SearchUserViewModel.swift
+++ b/gymroutine-mobile/Features/Sns/SearchUser/SearchUserViewModel.swift
@@ -1,4 +1,8 @@
+
+
+
 import Foundation
+import SwiftUI
 
 @MainActor
 final class SearchUserViewModel: ObservableObject {
@@ -11,6 +15,7 @@ final class SearchUserViewModel: ObservableObject {
     /// ユーザー名でユーザー検索を行い、結果を userDetails に設定する
     func fetchUsers() {
         Task {
+            UIApplication.showLoading()
             let result = await userService.searchUsersByName(name: searchName)
             switch result {
             case .success(let users):
@@ -19,6 +24,7 @@ final class SearchUserViewModel: ObservableObject {
             case .failure(let error):
                 errorMessage = error.localizedDescription
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Features/Workout/CreateWorkoutView.swift
+++ b/gymroutine-mobile/Features/Workout/CreateWorkoutView.swift
@@ -200,7 +200,9 @@ extension CreateWorkoutView {
                 
                 
                 Button {
-                    viewModel.onClickedCreateWorkoutButton()
+                    viewModel.onClickedCreateWorkoutButton() {
+                        dismiss()
+                    }
                 } label: {
                     Label("作成する", systemImage: "plus")
                 }

--- a/gymroutine-mobile/Features/Workout/CreateWorkoutViewModel.swift
+++ b/gymroutine-mobile/Features/Workout/CreateWorkoutViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import FirebaseAuth
+import SwiftUI
 
 enum Weekday: String, CaseIterable {
     case monday = "Monday"
@@ -56,6 +57,7 @@ class WorkoutExercisesManager: ObservableObject {
     }
 }
 
+@MainActor
 final class CreateWorkoutViewModel: WorkoutExercisesManager {
     @Published var workoutName: String = ""
     @Published var notes: String = ""
@@ -86,7 +88,7 @@ final class CreateWorkoutViewModel: WorkoutExercisesManager {
     }
     
     // ワークアウト作成
-    func onClickedCreateWorkoutButton() {
+    func onClickedCreateWorkoutButton(completion: @escaping () -> Void) {
         guard let userId = Auth.auth().currentUser?.uid else {
             fatalError("[ERROR] ログインしていません")
         }
@@ -105,15 +107,17 @@ final class CreateWorkoutViewModel: WorkoutExercisesManager {
             scheduledDays: sortedDays.map { $0.rawValue },
             exercises: self.exercises
         )
-        
         Task {
+            UIApplication.showLoading()
             let result = await service.createWorkout(workout: workout)
             switch result {
             case .success(_):
                 print("[DEBUG] ワークアウトの作成に成功しました！")
+                completion()    //View側にモーダル閉じを指示
             case .failure(let error):
                 print(error.localizedDescription)
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Features/Workout/CreateWorkoutViewModel.swift
+++ b/gymroutine-mobile/Features/Workout/CreateWorkoutViewModel.swift
@@ -44,10 +44,12 @@ class WorkoutExercisesManager: ObservableObject {
             part: exercise.part,
             sets: [ExerciseSet(reps: 0, weight: 0)])
         exercises.append(newWorkoutExercise)
+        UIApplication.showBanner(type: .success, message: "\(exercise.name)を追加しました")
     }
     
     func removeExercise(_ workoutExercise: WorkoutExercise) {
         exercises.removeAll { $0.id == workoutExercise.id }
+        UIApplication.showBanner(type: .notice, message: "\(workoutExercise.name)を削除しました")
     }
     
     func updateExerciseSet(for workoutExercise: WorkoutExercise) {
@@ -91,6 +93,11 @@ final class CreateWorkoutViewModel: WorkoutExercisesManager {
     func onClickedCreateWorkoutButton(completion: @escaping () -> Void) {
         guard let userId = Auth.auth().currentUser?.uid else {
             fatalError("[ERROR] ログインしていません")
+        }
+        
+        guard !self.workoutName.isEmpty else {
+            UIApplication.showBanner(type: .error, message: "ワークアウト名を入力してください")
+            return
         }
         
         // 週の順番にソート処理

--- a/gymroutine-mobile/ViewModels/PasswordResetViewModel.swift
+++ b/gymroutine-mobile/ViewModels/PasswordResetViewModel.swift
@@ -1,11 +1,15 @@
+
+
+
+
 import Foundation
 import FirebaseAuth
 import Combine
+import SwiftUI
 
 class PasswordResetViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var birthday: Date = Date()
-    @Published var errorMessage: String? = nil
     @Published var isResetLinkSent: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -21,7 +25,7 @@ class PasswordResetViewModel: ObservableObject {
     func sendPasswordReset() {
         // 入力チェック
         guard !email.isEmpty else {
-            errorMessage = "メールアドレスを入力してください。"
+            UIApplication.showBanner(type: .error, message: "メールアドレスを入力してください。")
             return
         }
 
@@ -31,9 +35,8 @@ class PasswordResetViewModel: ObservableObject {
                 switch result {
                 case .success:
                     self?.isResetLinkSent = true
-                    self?.errorMessage = nil
                 case .failure(let error):
-                    self?.errorMessage = error.localizedDescription
+                    UIApplication.showBanner(type: .error, message: error.localizedDescription)
                 }
             }
         }

--- a/gymroutine-mobile/ViewParts/OverlayViews/BannerView.swift
+++ b/gymroutine-mobile/ViewParts/OverlayViews/BannerView.swift
@@ -1,0 +1,101 @@
+//
+//  BannerView.swift
+//  gymroutine-mobile
+//  
+//  Created by SATTSAT on 2025/03/20
+//  
+//
+
+import SwiftUI
+
+enum BannerType {
+    case success
+    case error
+    case notice
+    
+    var color: Color {
+        switch self {
+        case .success:
+            return .green
+        case .error:
+            return .red
+        case .notice:
+            return .main
+        }
+    }
+    
+    var icon: String {
+        switch self {
+        case .success:
+            return "checkmark.circle.fill"
+        case .error:
+            return "xmark.circle.fill"
+        case .notice:
+            return "info.circle.fill"
+        }
+    }
+}
+
+struct BannerView: View {
+    
+    let type: BannerType
+    let message: String
+    
+    @State private var isVisible: Bool = false
+    private let generator = UINotificationFeedbackGenerator()
+    
+    var body: some View {
+        VStack {
+            if isVisible {
+                HStack(spacing: 16) {
+                    Image(systemName: type.icon)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 32, height: 32)
+                    
+                    Text(message)
+                        .hAlign(.leading)
+                }
+                .font(.headline)
+                .foregroundStyle(.white)
+                .padding(.vertical, 12)
+                .padding(.horizontal)
+                .hAlign(.leading)
+                .background(type.color)
+                .clipShape(Capsule())
+                .padding(.horizontal)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .animation(.spring(), value: isVisible)
+            }
+            
+            Spacer()
+        }
+        .padding(.top)
+        .onAppear {
+            vibration()
+            withAnimation {
+                isVisible = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                withAnimation {
+                    isVisible = false
+                }
+            }
+        }
+    }
+    
+    func vibration() {
+        switch self.type {
+        case .success:
+            self.generator.notificationOccurred(.success)
+        case .error:
+            self.generator.notificationOccurred(.error)
+        case .notice:
+            self.generator.notificationOccurred(.warning)
+        }
+    }
+}
+
+#Preview {
+    BannerView(type: .notice, message: "サンプルバナーです")
+}

--- a/gymroutine-mobile/ViewParts/OverlayViews/LoadingView.swift
+++ b/gymroutine-mobile/ViewParts/OverlayViews/LoadingView.swift
@@ -1,0 +1,68 @@
+//
+//  LoadingView.swift
+//  gymroutine-mobile
+//  
+//  Created by SATTSAT on 2025/03/20
+//  
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    
+    @State private var progress: CGFloat = 0.0
+    private let size: CGFloat = 70
+    
+    let message: String?
+    
+    init(message: String? = nil) {
+        self.message = message
+    }
+    
+    var body: some View {
+        Color.black.opacity(0.2)
+            .ignoresSafeArea()
+            .overlay(alignment: .center) {
+                VStack(spacing: 16) {
+                    ZStack(alignment: .bottom) {
+                        Color.primary
+                            
+                        
+                        Color.main
+                            .frame(height: size * progress, alignment: .bottom)
+                    }
+                    .frame(width: size, height: size)
+                    .mask(
+                        Image(systemName: "flame.fill")
+                            .resizable()
+                            .scaledToFit()
+                    )
+                    
+                    if let message {
+                        Text(message)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.1)
+                            .frame(maxWidth: size + 32)
+                    }
+                }
+                .padding(32)
+                .background(Color(UIColor.systemGray6))
+                .clipShape(.rect(cornerRadius: 8))
+                .shadow(color: Color.black.opacity(0.1), radius: 3, y: 1.5)
+                .offset(y: -20)
+                .onAppear {
+                    withAnimation(
+                        Animation.easeInOut(duration: 1.0)
+                            .repeatForever(autoreverses: true)
+                    ) {
+                        progress = 1.0
+                    }
+                }
+            }
+    }
+}
+
+#Preview {
+    LoadingView(message: "サンプル")
+    LoadingView()
+}

--- a/gymroutine-mobile/Views/FollowersListView.swift
+++ b/gymroutine-mobile/Views/FollowersListView.swift
@@ -45,6 +45,7 @@ struct FollowersListView: View {
         }
         .navigationTitle("フォロワー")
         .task {
+            UIApplication.showLoading()
             print("DEBUG: Loading followers list for userID: \(userID)")
             let result = await followService.getFollowers(for: userID)
             switch result {
@@ -55,6 +56,7 @@ struct FollowersListView: View {
                 print("ERROR: Failed to fetch followers: \(error.localizedDescription)")
                 errorMessage = error.localizedDescription
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Views/FollowingListView.swift
+++ b/gymroutine-mobile/Views/FollowingListView.swift
@@ -45,6 +45,7 @@ struct FollowingListView: View {
         }
         .navigationTitle("フォロー中")
         .task {
+            UIApplication.showLoading()
             print("DEBUG: Loading following list for userID: \(userID)")
             let result = await followService.getFollowing(for: userID)
             switch result {
@@ -55,6 +56,7 @@ struct FollowingListView: View {
                 print("ERROR: Failed to fetch following users: \(error.localizedDescription)")
                 errorMessage = error.localizedDescription
             }
+            UIApplication.hideLoading()
         }
     }
 }

--- a/gymroutine-mobile/Views/PasswordResetView.swift
+++ b/gymroutine-mobile/Views/PasswordResetView.swift
@@ -21,6 +21,7 @@ struct PasswordResetView: View {
             }
             .padding(.bottom, 16)
             .padding([.top, .horizontal], 24)
+            .background()
             .navigationTitle("パスワードのリセット")
             .navigationBarTitleDisplayMode(.inline)
         }
@@ -62,10 +63,7 @@ struct PasswordResetView: View {
 
     private var resetStatusMessage: some View {
         Group {
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .foregroundColor(.red)
-            } else if viewModel.isResetLinkSent {
+            if viewModel.isResetLinkSent {
                 Text("リセットリンクを送信しました。メールを確認してください。")
                     .foregroundColor(.green)
             }


### PR DESCRIPTION
## ローディング画面・バナー画面を実装しました
### 実装したこと
- UIApplicationのExtensionの実装
- 非同期処理につけるLoading画面を実装
- ユーザーにアクションの結果を示すBanner画面の実装

### スクリーンショット
| LoadingView  |
|------------|
| <img src="https://github.com/user-attachments/assets/a5772d2c-1010-4ddb-b549-7441eee935c0" alt="IMG_3472" width="300px" />  |  

#### BannerView(3種類)
| Success  | Notice  | Error  |
|------------|------------|------------|
| <img src="https://github.com/user-attachments/assets/e6e2b29a-e12f-41f5-899d-160eda52e6d0" alt="IMG_3472" width="200px" />  |  <img src="https://github.com/user-attachments/assets/44b60795-9f0f-414c-9ee6-a5a36563ac59" alt="IMG_3472" width="200px" />  |  <img src="https://github.com/user-attachments/assets/651f9c3a-1124-44f9-a823-b23719eb4bda" alt="IMG_3472" width="200px" />  |  



### 使い方
どちらも使用箇所はいずれかのViewModelに適応します。UIApplicationを扱うので、使用する際はSwiftUIもしくはUIKitのimportが必要になります。
```swift
import SwiftUI
```
#### LoadingView
Loading Viewを表示している間はその他のViewをいじれなくしてあります。
非同期処理を始める一番最初に表示する **UIApplication.showLoading()** を呼び出し、処理が終了した際に非表示にする **UIApplication.hideLoading()** を呼び出すことで、非同期処理中はユーザーの操作を許さず、予期せぬ挙動を防げます。
```swift
    func exampleAsyncFunction() {
        Task {
            UIApplication.showLoading()
            let result = await service.createWorkout(workout: workout)
            switch result {
            case .success(_):
                print("[DEBUG] ワークアウトの作成に成功しました！")
            case .failure(let error):
                print(error.localizedDescription)
            }
            UIApplication.hideLoading()
        }
```


#### BannerView
ユーザーにアクションの結果を示したいときに使います。成功、失敗、お知らせの3種類用意しているので、最も適したバナーを表示してください。
```swift
    func Example() {
        guard !self.workoutName.isEmpty else {
            UIApplication.showBanner(type: .error, message: "ワークアウト名を入力してください")
            return
        }
```







