### PR TITLE
fix: 運動記録がないときのアラート文を修正

### DIFF
--- a/gymroutine-mobile/Features/Analytics/AnalyticsView.swift
+++ b/gymroutine-mobile/Features/Analytics/AnalyticsView.swift
@@ -96,10 +96,8 @@ struct AnalyticsView: View {
         }
         .alert(isPresented: $viewModel.showingUpdateAlert) {
             Alert(
-                title: Text(viewModel.updateSuccess ? "分析完了" : "分析失敗"),
-                message: Text(viewModel.updateSuccess 
-                              ? "分析データが更新されました。しばらくしてからもう一度確認してください。"
-                              : "分析データの更新に失敗しました。\(viewModel.errorMessage)"),
+                title: Text(viewModel.getAlertTitle()),
+                message: Text(viewModel.alertMessage),
                 dismissButton: .default(Text("確認")) {
                     if viewModel.updateSuccess {
                         // 更新成功時、5秒後にデータを再読み込み

--- a/gymroutine-mobile/Features/Analytics/AnalyticsViewModel.swift
+++ b/gymroutine-mobile/Features/Analytics/AnalyticsViewModel.swift
@@ -12,8 +12,8 @@ class AnalyticsViewModel: ObservableObject {
     // 알림 관련 상태 변수
     @Published var showingUpdateAlert = false
     @Published var updateSuccess = false
-    @Published var errorMessage = ""
-    
+    @Published var alertMessage = ""
+
     private let userAnalyticsService = UserAnalyticsService.shared
     private let db = Firestore.firestore()
     private let userManager = UserManager.shared
@@ -81,7 +81,7 @@ class AnalyticsViewModel: ObservableObject {
             guard let self = self else { return }
             
             self.updateSuccess = success
-            self.errorMessage = error?.localizedDescription ?? ""
+            self.alertMessage = getAlertMessage(error: error)
             self.showingUpdateAlert = true
         }
     }
@@ -131,8 +131,8 @@ class AnalyticsViewModel: ObservableObject {
                         Task {
                             await self?.loadUserData()
                         }
+                        completion(success, nil)
                     }
-                    completion(success, nil)
                 }
             }
         }
@@ -190,6 +190,21 @@ class AnalyticsViewModel: ObservableObject {
             return "あなたはフォロー中のユーザーより週に\(abs(diff))回少なく運動しています"
         } else {
             return "あなたはフォロー中のユーザーと同じくらい運動しています"
+        }
+    }
+
+    func getAlertTitle() -> String {
+        return updateSuccess ? "分析完了" : "更新エラー"
+    }
+
+    func getAlertMessage(error: Error?) -> String {
+        if updateSuccess {
+            return "分析データが更新されました。しばらくしてからもう一度確認してください。"
+        } else {
+            if let error = error as? NSError, error.code == 1001 {
+                return "運動記録がないため分析できません。"
+            }
+            return "分析データの更新に失敗しました。"
         }
     }
 }

--- a/gymroutine-mobile/Services/UserAnalyticsService.swift
+++ b/gymroutine-mobile/Services/UserAnalyticsService.swift
@@ -89,19 +89,42 @@ class UserAnalyticsService {
             
             if let resultData = result?.data as? [String: Any] {
                 print("Function response: \(resultData)")
-                
                 // successキーがある場合は使用、ない場合やBool値でない場合はfalseを返す
                 if let success = resultData["success"] as? Bool {
-                    completion(success, nil)
-                } else {
-                    print("Success key not found in response or not a boolean")
-                    completion(false, nil)
+                    if success {
+                        completion(success, nil)
+                    } else {
+                        if let errorMessage = resultData["message"] as? String,
+                           errorMessage == "No workout data available for analysis" {
+                            // No Data用のエラーを吐く
+                            completion(
+                                false,
+                                NSError(
+                                    domain: "AnalyticsService",
+                                    code: 1001,
+                                    userInfo: [NSLocalizedDescriptionKey: "分析に必要なデータが記録されていません。"]
+                                )
+                            )
+                            return
+                        }
+                    }
                 }
             } else {
                 print("Unexpected response format. Raw result: \(String(describing: result?.data))")
-                completion(false, NSError(domain: "AnalyticsService", code: 500, 
-                                        userInfo: [NSLocalizedDescriptionKey: "サーバーレスポンスの形式が正しくありません。"]))
+                completion(false, NSError(domain: "AnalyticsService", code: 500,
+                                          userInfo: [NSLocalizedDescriptionKey: "サーバーレスポンスの形式が正しくありません。"]))
+                return
             }
+
+            completion(
+                false,
+                NSError(
+                    domain: "AnalyticsService",
+                    code: 9999,
+                    userInfo: [NSLocalizedDescriptionKey: "unknown error"]
+                )
+            )
+            return
         }
     }
     


### PR DESCRIPTION
アラート文をエラーによって分岐

- シンプルなエラー：`"分析データの更新に失敗しました。"`
- 運動記録がないエラー： `"運動記録がないため分析できません。"`

<img src="https://github.com/user-attachments/assets/458c5b0c-ee4b-4ae1-9fe3-82bc27426838" alt="スクリーンショット" width="300">

